### PR TITLE
Development regenerate access token and logout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "com.koleff.kare_android"
         minSdk 24
         targetSdk 34
-        versionCode 13
-        versionName "2.4"
+        versionCode 14
+        versionName "2.5"
         multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/androidTest/java/com/koleff/kare_android/authentication/broadcast_receiver/AuthenticationBroadcastReceiverTest.kt
+++ b/app/src/androidTest/java/com/koleff/kare_android/authentication/broadcast_receiver/AuthenticationBroadcastReceiverTest.kt
@@ -45,6 +45,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
+import javax.inject.Provider
 
 @RunWith(AndroidJUnit4::class)
 class AuthenticationBroadcastReceiverTest {
@@ -56,6 +57,7 @@ class AuthenticationBroadcastReceiverTest {
         private lateinit var credentialsValidator: CredentialsValidator
         private lateinit var credentialsDataStoreFake: CredentialsDataStoreFake
         private lateinit var authenticationUseCases: AuthenticationUseCases
+        private lateinit var authenticationUseCasesProvider: Provider<AuthenticationUseCases>
         private lateinit var authenticationRepository: AuthenticationRepository
         private lateinit var authenticationDataSource: AuthenticationDataSource
         private lateinit var userRepository: UserRepository
@@ -108,10 +110,11 @@ class AuthenticationBroadcastReceiverTest {
                 logoutUseCase = LogoutUseCase(authenticationRepository),
                 regenerateTokenUseCase = RegenerateTokenUseCase(authenticationRepository)
             )
+            authenticationUseCasesProvider = Provider { authenticationUseCases }
 
             navigationControllerFake = NavigationControllerFake()
             logoutHandler = LogoutHandler(
-                authenticationUseCases = authenticationUseCases,
+                authenticationUseCases = authenticationUseCasesProvider,
                 credentialsDataStore = credentialsDataStoreFake,
                 navigationController = navigationControllerFake
             )
@@ -121,7 +124,7 @@ class AuthenticationBroadcastReceiverTest {
             )
 
             regenerateTokenHandler = RegenerateTokenHandler(
-                authenticationUseCases = authenticationUseCases,
+                authenticationUseCases = authenticationUseCasesProvider,
                 tokenDataStore = tokenDataStoreFake
             )
             regenerateTokenBroadcastReceiver = RegenerateTokenBroadcastReceiver(

--- a/app/src/androidTest/java/com/koleff/kare_android/authentication/view_model/SplashScreenViewModelTest.kt
+++ b/app/src/androidTest/java/com/koleff/kare_android/authentication/view_model/SplashScreenViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.koleff.kare_android.view_model.authentication
+package com.koleff.kare_android.authentication.view_model
 
 import app.cash.turbine.test
 import com.koleff.kare_android.authentication.data.CredentialsDataStoreFake

--- a/app/src/androidTest/java/com/koleff/kare_android/broadcast_receiver/authentication/AuthenticationBroadcastReceiverTest.kt
+++ b/app/src/androidTest/java/com/koleff/kare_android/broadcast_receiver/authentication/AuthenticationBroadcastReceiverTest.kt
@@ -1,0 +1,150 @@
+package com.koleff.kare_android.broadcast_receiver.authentication
+
+import android.content.Intent
+import androidx.test.platform.app.InstrumentationRegistry
+import com.koleff.kare_android.authentication.data.CredentialsDataStoreFake
+import com.koleff.kare_android.authentication.data.NavigationControllerFake
+import com.koleff.kare_android.authentication.data.TokenDataStoreFake
+import com.koleff.kare_android.authentication.data.UserDaoFake
+import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.auth.CredentialsAuthenticator
+import com.koleff.kare_android.common.auth.CredentialsAuthenticatorImpl
+import com.koleff.kare_android.common.auth.CredentialsValidator
+import com.koleff.kare_android.common.auth.CredentialsValidatorImpl
+import com.koleff.kare_android.common.broadcast.LogoutBroadcastReceiver
+import com.koleff.kare_android.common.broadcast.LogoutHandler
+import com.koleff.kare_android.common.broadcast.RegenerateTokenBroadcastReceiver
+import com.koleff.kare_android.common.broadcast.RegenerateTokenHandler
+import com.koleff.kare_android.data.datasource.AuthenticationDataSource
+import com.koleff.kare_android.data.datasource.AuthenticationLocalDataSource
+import com.koleff.kare_android.data.datasource.UserDataSource
+import com.koleff.kare_android.data.datasource.UserLocalDataSource
+import com.koleff.kare_android.data.repository.AuthenticationRepositoryImpl
+import com.koleff.kare_android.data.repository.UserRepositoryImpl
+import com.koleff.kare_android.domain.repository.AuthenticationRepository
+import com.koleff.kare_android.domain.repository.UserRepository
+import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
+import com.koleff.kare_android.domain.usecases.LoginUseCase
+import com.koleff.kare_android.domain.usecases.LogoutUseCase
+import com.koleff.kare_android.domain.usecases.RegenerateTokenUseCase
+import com.koleff.kare_android.domain.usecases.RegisterUseCase
+import com.koleff.kare_android.utils.TestLogger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+
+class AuthenticationBroadcastReceiverTest {
+
+    companion object {
+        private lateinit var dispatcher: CoroutineDispatcher
+
+        private lateinit var credentialsAuthenticator: CredentialsAuthenticator
+        private lateinit var credentialsValidator: CredentialsValidator
+        private lateinit var credentialsDataStoreFake: CredentialsDataStoreFake
+        private lateinit var authenticationUseCases: AuthenticationUseCases
+        private lateinit var authenticationRepository: AuthenticationRepository
+        private lateinit var authenticationDataSource: AuthenticationDataSource
+        private lateinit var userRepository: UserRepository
+        private lateinit var userDataSource: UserDataSource
+        private lateinit var userDao: UserDaoFake
+
+        private val isLogging = true
+        private lateinit var logger: TestLogger
+
+        private lateinit var navigationControllerFake: NavigationControllerFake
+        private lateinit var logoutHandler: LogoutHandler
+        private lateinit var logoutBroadcastReceiver: LogoutBroadcastReceiver
+
+        private lateinit var tokenDataStoreFake: TokenDataStoreFake
+        private lateinit var regenerateTokenHandler: RegenerateTokenHandler
+        private lateinit var regenerateTokenBroadcastReceiver: RegenerateTokenBroadcastReceiver
+
+        private const val TAG = "AuthenticationBroadcastReceiverTest"
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+            dispatcher = StandardTestDispatcher()
+            Dispatchers.setMain(dispatcher)
+
+            userDao = UserDaoFake()
+            userDataSource = UserLocalDataSource(userDao)
+            userRepository = UserRepositoryImpl(userDataSource)
+
+            credentialsValidator = CredentialsValidatorImpl(userRepository)
+            credentialsDataStoreFake = CredentialsDataStoreFake() //No caching needed for testing
+            credentialsAuthenticator =
+                CredentialsAuthenticatorImpl(credentialsValidator, credentialsDataStoreFake)
+
+            authenticationDataSource = AuthenticationLocalDataSource(
+                userDao,
+                credentialsAuthenticator as CredentialsAuthenticatorImpl
+            )
+            authenticationRepository = AuthenticationRepositoryImpl(authenticationDataSource)
+
+            authenticationUseCases = AuthenticationUseCases(
+                loginUseCase = LoginUseCase(authenticationRepository, credentialsAuthenticator),
+                registerUseCase = RegisterUseCase(
+                    authenticationRepository,
+                    credentialsAuthenticator
+                ),
+                logoutUseCase = LogoutUseCase(authenticationRepository),
+                regenerateTokenUseCase = RegenerateTokenUseCase(authenticationRepository)
+            )
+
+            navigationControllerFake = NavigationControllerFake()
+            logoutHandler = LogoutHandler(
+                authenticationUseCases = authenticationUseCases,
+                credentialsDataStore = credentialsDataStoreFake,
+                navigationController = navigationControllerFake
+            )
+
+            logoutBroadcastReceiver = LogoutBroadcastReceiver(
+                logoutHandler = logoutHandler
+            )
+
+            regenerateTokenHandler = RegenerateTokenHandler(
+                authenticationUseCases = authenticationUseCases,
+                tokenDataStore = tokenDataStoreFake
+            )
+            regenerateTokenBroadcastReceiver = RegenerateTokenBroadcastReceiver(
+                regenerateTokenHandler = regenerateTokenHandler
+            )
+
+            logger = TestLogger(isLogging)
+        }
+    }
+
+    @Test
+    fun logoutUseCaseTest() = runTest {
+        val logoutIntent = Intent(Constants.ACTION_LOGOUT)
+
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+        logoutBroadcastReceiver.onReceive(appContext, logoutIntent)
+
+        assertTrue(credentialsDataStoreFake.isCleared)
+
+        assertTrue(navigationControllerFake.isBackstackCleared)
+        assertNotNull(navigationControllerFake.lastDestination)
+    }
+
+    @Test
+    fun regenerateTokenUseCaseTest() = runTest {
+        val regenerateTokenIntent = Intent(Constants.ACTION_REGENERATE_TOKEN)
+
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+        regenerateTokenBroadcastReceiver.onReceive(appContext, regenerateTokenIntent)
+
+        assertNotNull(tokenDataStoreFake.getTokens())
+    }
+}

--- a/app/src/androidTest/java/com/koleff/kare_android/view_model/authentication/SplashScreenViewModelTest.kt
+++ b/app/src/androidTest/java/com/koleff/kare_android/view_model/authentication/SplashScreenViewModelTest.kt
@@ -22,6 +22,7 @@ import com.koleff.kare_android.domain.repository.UserRepository
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import com.koleff.kare_android.domain.usecases.LoginUseCase
 import com.koleff.kare_android.domain.usecases.LogoutUseCase
+import com.koleff.kare_android.domain.usecases.RegenerateTokenUseCase
 import com.koleff.kare_android.domain.usecases.RegisterUseCase
 import com.koleff.kare_android.ui.state.LoginData
 import com.koleff.kare_android.ui.state.LoginState
@@ -105,7 +106,8 @@ class SplashScreenViewModelTest {
                     authenticationRepository,
                     credentialsAuthenticator
                 ),
-                logoutUseCase = LogoutUseCase(authenticationRepository)
+                logoutUseCase = LogoutUseCase(authenticationRepository),
+                regenerateTokenUseCase = RegenerateTokenUseCase(authenticationRepository)
             )
 
             logger = TestLogger(isLogging)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,18 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <receiver android:name=".common.broadcast.LogoutBroadcastReceiver" android:exported="false">
+            <intent-filter>
+                <action android:name="com.koleff.kare_android.ACTION_LOGOUT" />
+            </intent-filter>
+        </receiver>
+
+        <receiver android:name=".common.broadcast.RegenerateTokenBroadcastReceiver" android:exported="false">
+            <intent-filter>
+                <action android:name="com.koleff.kare_android.ACTION_REGENERATE_TOKEN" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/koleff/kare_android/KareApp.kt
+++ b/app/src/main/java/com/koleff/kare_android/KareApp.kt
@@ -2,6 +2,7 @@ package com.koleff.kare_android
 
 import android.content.IntentFilter
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.multidex.MultiDexApplication
 import com.koleff.kare_android.common.Constants
@@ -104,10 +105,10 @@ class KareApp : MultiDexApplication(), DefaultLifecycleObserver {
         }
     }
 
-//    override fun onDestroy(owner: LifecycleOwner) {
-//        super.onDestroy(owner)
-//
-//        broadcastManager.unregisterReceiver(regenerateTokenBroadcastReceiver)
-//        broadcastManager.unregisterReceiver(logoutBroadcastReceiver)
-//    }
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+
+        broadcastManager.unregisterReceiver(regenerateTokenBroadcastReceiver)
+        broadcastManager.unregisterReceiver(logoutBroadcastReceiver)
+    }
 }

--- a/app/src/main/java/com/koleff/kare_android/KareApp.kt
+++ b/app/src/main/java/com/koleff/kare_android/KareApp.kt
@@ -1,9 +1,14 @@
 package com.koleff.kare_android
 
+import android.content.IntentFilter
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.multidex.MultiDexApplication
+import com.koleff.kare_android.common.Constants
 import com.koleff.kare_android.common.Constants.useLocalDataSource
 import com.koleff.kare_android.common.NotificationManager
+import com.koleff.kare_android.common.broadcast.LogoutBroadcastReceiver
+import com.koleff.kare_android.common.broadcast.RegenerateTokenBroadcastReceiver
 import com.koleff.kare_android.common.preferences.Preferences
 import com.koleff.kare_android.data.room.manager.ExerciseDBManagerV2
 import com.koleff.kare_android.data.room.manager.UserDBManager
@@ -18,6 +23,11 @@ import javax.inject.Inject
 @HiltAndroidApp
 class KareApp : MultiDexApplication(), DefaultLifecycleObserver {
 
+
+    /**
+     * Local Room DB Managers
+     */
+
     @Inject
     lateinit var exerciseDBManager: ExerciseDBManagerV2
 
@@ -27,8 +37,29 @@ class KareApp : MultiDexApplication(), DefaultLifecycleObserver {
     @Inject
     lateinit var userDBManager: UserDBManager
 
+    /**
+     * Shared preferences
+     */
+
     @Inject
     lateinit var preferences: Preferences
+
+    /**
+     * Broadcast Manager
+     */
+
+    @Inject
+    lateinit var broadcastManager: LocalBroadcastManager
+
+    /**
+     * Broadcast Receivers
+     */
+
+    @Inject
+    lateinit var regenerateTokenBroadcastReceiver: RegenerateTokenBroadcastReceiver
+
+    @Inject
+    lateinit var logoutBroadcastReceiver: LogoutBroadcastReceiver
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun onCreate() {
@@ -52,6 +83,18 @@ class KareApp : MultiDexApplication(), DefaultLifecycleObserver {
             }
 
         }
+
+        //Register broadcast receivers
+        broadcastManager.registerReceiver(
+            regenerateTokenBroadcastReceiver,
+            IntentFilter(Constants.ACTION_REGENERATE_TOKEN)
+        )
+
+        broadcastManager.registerReceiver(
+            logoutBroadcastReceiver,
+            IntentFilter(Constants.ACTION_LOGOUT)
+        )
+
         //Create push notification channel
         NotificationManager.createNotificationChannel(this@KareApp)
 
@@ -60,4 +103,11 @@ class KareApp : MultiDexApplication(), DefaultLifecycleObserver {
             NotificationManager.subscribeToTopic()
         }
     }
+
+//    override fun onDestroy(owner: LifecycleOwner) {
+//        super.onDestroy(owner)
+//
+//        broadcastManager.unregisterReceiver(regenerateTokenBroadcastReceiver)
+//        broadcastManager.unregisterReceiver(logoutBroadcastReceiver)
+//    }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/Constants.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/Constants.kt
@@ -30,4 +30,11 @@ object Constants {
 
     const val isTestingFirebaseCrashlytics = false
     const val CATALOG_EXERCISE_ID = 777
+
+    /**
+     * Broadcast intents
+     */
+    const val ACTION_LOGOUT = "com.koleff.kare_android.ACTION_LOGOUT"
+    const val ACTION_REGENERATE_TOKEN = "com.koleff.kare_android.ACTION_REGENERATE_TOKEN"
+
 }

--- a/app/src/main/java/com/koleff/kare_android/common/MockupDataGeneratorV2.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/MockupDataGeneratorV2.kt
@@ -5,6 +5,7 @@ import com.koleff.kare_android.data.model.dto.ExerciseDto
 import com.koleff.kare_android.data.model.dto.ExerciseSetDto
 import com.koleff.kare_android.data.model.dto.ExerciseTime
 import com.koleff.kare_android.data.model.dto.MuscleGroup
+import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.WorkoutConfigurationDto
 import com.koleff.kare_android.data.model.dto.WorkoutDetailsDto
 import com.koleff.kare_android.data.model.dto.WorkoutDto
@@ -329,5 +330,13 @@ object MockupDataGeneratorV2 {
         )
 
         return Pair(workout, workoutDetails)
+    }
+
+    //TODO: generate random access_token and keep the same refresh_token...
+    fun generateTokens(): Tokens {
+        return Tokens(
+            accessToken = "access_token",
+            refreshToken = "refresh_token"
+        )
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/auth/CredentialsAuthenticatorImpl.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/auth/CredentialsAuthenticatorImpl.kt
@@ -1,5 +1,6 @@
 package com.koleff.kare_android.common.auth
 
+import com.koleff.kare_android.common.preferences.CredentialsDataStore
 import com.koleff.kare_android.data.model.response.base_response.KareError
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.ui.state.BaseState

--- a/app/src/main/java/com/koleff/kare_android/common/auth/CredentialsDataStore.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/auth/CredentialsDataStore.kt
@@ -1,7 +1,0 @@
-package com.koleff.kare_android.common.auth
-
-interface CredentialsDataStore {
-
-    fun getCredentials(): Credentials?
-    fun saveCredentials(credentials: Credentials)
-}

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
@@ -4,45 +4,16 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import android.widget.Toast
-import android.widget.Toast.LENGTH_SHORT
-import com.koleff.kare_android.common.navigation.Destination
-import com.koleff.kare_android.common.navigation.NavigationController
-import com.koleff.kare_android.common.preferences.Preferences
-import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class LogoutBroadcastReceiver @Inject constructor(
-    private val authenticationUseCases: AuthenticationUseCases,
-    private val preferences: Preferences,
-    private val navigationController: NavigationController
+    private val logoutHandler: LogoutHandler
 ) : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("LogoutBroadcastReceiver", "Logout broadcast received.")
-
-        val credentials = preferences.getCredentials() ?: return
-
-        CoroutineScope(Dispatchers.IO).launch {
-            authenticationUseCases.logoutUseCase.invoke(credentials)
-                .collect{ logoutState ->
-                if(logoutState.isSuccessful){
-                    Log.d("LogoutBroadcastReceiver", "Logout done successfully!")
-
-                    //Navigate to Welcome screen...
-                    navigationController.clearBackstackAndNavigateTo(Destination.Welcome)
-                }else if(logoutState.isError){
-                    Log.d("LogoutBroadcastReceiver", "Logout failed!")
-
-                    val toast = Toast.makeText(context, "Logout failed.", LENGTH_SHORT)
-                    toast.show()
-                }
-            }
-        }
+        logoutHandler.logout(context)
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
@@ -10,23 +10,19 @@ import com.koleff.kare_android.common.navigation.Destination
 import com.koleff.kare_android.common.navigation.NavigationController
 import com.koleff.kare_android.common.preferences.Preferences
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@AndroidEntryPoint
-class LogoutBroadcastReceiver : BroadcastReceiver() {
+@Singleton
+class LogoutBroadcastReceiver @Inject constructor(
+    private val authenticationUseCases: AuthenticationUseCases,
+    private val preferences: Preferences,
+    private val navigationController: NavigationController
+) : BroadcastReceiver() {
 
-    @Inject
-    lateinit var authenticationUseCases: AuthenticationUseCases
-
-    @Inject
-    lateinit var preferences: Preferences
-
-    @Inject
-    lateinit var navigationController: NavigationController
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("LogoutBroadcastReceiver", "Logout broadcast received.")
 

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
@@ -1,0 +1,52 @@
+package com.koleff.kare_android.common.broadcast
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import android.widget.Toast.LENGTH_SHORT
+import com.koleff.kare_android.common.navigation.Destination
+import com.koleff.kare_android.common.navigation.NavigationController
+import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class LogoutBroadcastReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var authenticationUseCases: AuthenticationUseCases
+
+    @Inject
+    lateinit var preferences: Preferences
+
+    @Inject
+    lateinit var navigationController: NavigationController
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d("LogoutBroadcastReceiver", "Logout broadcast received.")
+
+        val credentials = preferences.getCredentials() ?: return
+
+        CoroutineScope(Dispatchers.IO).launch {
+            authenticationUseCases.logoutUseCase.invoke(credentials)
+                .collect{ logoutState ->
+                if(logoutState.isSuccessful){
+                    Log.d("LogoutBroadcastReceiver", "Logout done successfully!")
+
+                    //Navigate to Welcome screen...
+                    navigationController.clearBackstackAndNavigateTo(Destination.Welcome)
+                }else if(logoutState.isError){
+                    Log.d("LogoutBroadcastReceiver", "Logout failed!")
+
+                    val toast = Toast.makeText(context, "Logout failed.", LENGTH_SHORT)
+                    toast.show()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutBroadcastReceiver.kt
@@ -5,9 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class LogoutBroadcastReceiver @Inject constructor(
     private val logoutHandler: LogoutHandler
 ) : BroadcastReceiver() {

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
@@ -3,17 +3,18 @@ package com.koleff.kare_android.common.broadcast
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
-import com.koleff.kare_android.common.preferences.CredentialsDataStore
 import com.koleff.kare_android.common.navigation.Destination
 import com.koleff.kare_android.common.navigation.NavigationController
+import com.koleff.kare_android.common.preferences.CredentialsDataStore
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Provider
 
 class LogoutHandler @Inject constructor(
-    private val authenticationUseCases: AuthenticationUseCases,
+    private val authenticationUseCases: Provider<AuthenticationUseCases>,
     private val credentialsDataStore: CredentialsDataStore,
     private val navigationController: NavigationController
 ) {
@@ -24,7 +25,7 @@ class LogoutHandler @Inject constructor(
         val credentials = credentialsDataStore.getCredentials() ?: return
 
         CoroutineScope(Dispatchers.IO).launch {
-            authenticationUseCases.logoutUseCase.invoke(credentials)
+            authenticationUseCases.get().logoutUseCase.invoke(credentials)
                 .collect{ logoutState ->
                     if(logoutState.isSuccessful){
                         Log.d("LogoutHandler", "Logout done successfully!")

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@Singleton
 class LogoutHandler @Inject constructor(
     private val authenticationUseCases: AuthenticationUseCases,
     private val preferences: Preferences,

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
@@ -3,26 +3,25 @@ package com.koleff.kare_android.common.broadcast
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
+import com.koleff.kare_android.common.preferences.CredentialsDataStore
 import com.koleff.kare_android.common.navigation.Destination
 import com.koleff.kare_android.common.navigation.NavigationController
-import com.koleff.kare_android.common.preferences.Preferences
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Singleton
 
 class LogoutHandler @Inject constructor(
     private val authenticationUseCases: AuthenticationUseCases,
-    private val preferences: Preferences,
+    private val credentialsDataStore: CredentialsDataStore,
     private val navigationController: NavigationController
 ) {
 
      fun logout(context: Context){
         Log.d("LogoutHandler", "Logout handler received.")
 
-        val credentials = preferences.getCredentials() ?: return
+        val credentials = credentialsDataStore.getCredentials() ?: return
 
         CoroutineScope(Dispatchers.IO).launch {
             authenticationUseCases.logoutUseCase.invoke(credentials)

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/LogoutHandler.kt
@@ -1,0 +1,45 @@
+package com.koleff.kare_android.common.broadcast
+
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import com.koleff.kare_android.common.navigation.Destination
+import com.koleff.kare_android.common.navigation.NavigationController
+import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LogoutHandler @Inject constructor(
+    private val authenticationUseCases: AuthenticationUseCases,
+    private val preferences: Preferences,
+    private val navigationController: NavigationController
+) {
+
+     fun logout(context: Context){
+        Log.d("LogoutHandler", "Logout handler received.")
+
+        val credentials = preferences.getCredentials() ?: return
+
+        CoroutineScope(Dispatchers.IO).launch {
+            authenticationUseCases.logoutUseCase.invoke(credentials)
+                .collect{ logoutState ->
+                    if(logoutState.isSuccessful){
+                        Log.d("LogoutHandler", "Logout done successfully!")
+
+                        //Navigate to Welcome screen...
+                        navigationController.clearBackstackAndNavigateTo(Destination.Welcome)
+                    }else if(logoutState.isError){
+                        Log.d("LogoutHandler", "Logout failed!")
+
+                        val toast = Toast.makeText(context, "Logout failed.", Toast.LENGTH_SHORT)
+                        toast.show()
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
@@ -5,10 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import javax.inject.Inject
-import javax.inject.Singleton
 
-
-@Singleton
 class RegenerateTokenBroadcastReceiver @Inject constructor(
     private val regenerateTokenHandler: RegenerateTokenHandler
 ) : BroadcastReceiver() {

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
@@ -4,44 +4,65 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import com.koleff.kare_android.common.network.RegenerateTokenNotifier
 import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.data.model.response.base_response.KareError
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
-import dagger.hilt.android.AndroidEntryPoint
+import com.koleff.kare_android.ui.state.TokenState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Singleton
 
 
-@AndroidEntryPoint
-class RegenerateTokenBroadcastReceiver : BroadcastReceiver() {
+@Singleton
+class RegenerateTokenBroadcastReceiver @Inject constructor(
+    private val authenticationUseCases: AuthenticationUseCases,
+    private val preferences: Preferences
+) : BroadcastReceiver(), RegenerateTokenNotifier {
 
-    @Inject
-    lateinit var authenticationUseCases: AuthenticationUseCases
+    private val _regenerateTokenState = MutableSharedFlow<TokenState>(replay = 1)
+    override val regenerateTokenState: Flow<TokenState> = _regenerateTokenState.asSharedFlow()
 
-    @Inject
-    lateinit var preferences: Preferences
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token broadcast received.")
 
-        val tokens = preferences.getTokens() ?: return
+        val tokens = preferences.getTokens()
 
         CoroutineScope(Dispatchers.IO).launch {
+
+            //Validation
+            tokens ?: run {
+                _regenerateTokenState.emit(
+                    TokenState(
+                        isError = true,
+                        error = KareError.INVALID_TOKEN
+                    )
+                )
+
+                return@launch
+            }
+
             authenticationUseCases.regenerateTokenUseCase.invoke(tokens)
                 .collect { regenerateTokenState ->
+                    Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token state received. State: $regenerateTokenState")
+                    _regenerateTokenState.emit(regenerateTokenState)
+
                     if (regenerateTokenState.isSuccessful) {
                         Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token successfully done!")
 
-                        //Update preferences with new tokens
+                        //Update preferences with new auth tokens
                         preferences.updateTokens(regenerateTokenState.tokens)
                     } else if (regenerateTokenState.isError) {
                         Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token failed!")
                         Log.d("RegenerateTokenBroadcastReceiver", "Logging out...")
 
-                        //Logout
+                        //Delete existing auth tokens
                         preferences.deleteTokens()
-
-                        //Send logout broadcast
                     }
                 }
         }

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
@@ -1,0 +1,49 @@
+package com.koleff.kare_android.common.broadcast
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+@AndroidEntryPoint
+class RegenerateTokenBroadcastReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var authenticationUseCases: AuthenticationUseCases
+
+    @Inject
+    lateinit var preferences: Preferences
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token broadcast received.")
+
+        val tokens = preferences.getTokens() ?: return
+
+        CoroutineScope(Dispatchers.IO).launch {
+            authenticationUseCases.regenerateTokenUseCase.invoke(tokens)
+                .collect { regenerateTokenState ->
+                    if (regenerateTokenState.isSuccessful) {
+                        Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token successfully done!")
+
+                        //Update preferences with new tokens
+                        preferences.updateTokens(regenerateTokenState.tokens)
+                    } else if (regenerateTokenState.isError) {
+                        Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token failed!")
+                        Log.d("RegenerateTokenBroadcastReceiver", "Logging out...")
+
+                        //Logout
+                        preferences.deleteTokens()
+
+                        //Send logout broadcast
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenBroadcastReceiver.kt
@@ -4,67 +4,17 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import com.koleff.kare_android.common.network.RegenerateTokenNotifier
-import com.koleff.kare_android.common.preferences.Preferences
-import com.koleff.kare_android.data.model.response.base_response.KareError
-import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
-import com.koleff.kare_android.ui.state.TokenState
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 
 @Singleton
 class RegenerateTokenBroadcastReceiver @Inject constructor(
-    private val authenticationUseCases: AuthenticationUseCases,
-    private val preferences: Preferences
-) : BroadcastReceiver(), RegenerateTokenNotifier {
-
-    private val _regenerateTokenState = MutableSharedFlow<TokenState>(replay = 1)
-    override val regenerateTokenState: Flow<TokenState> = _regenerateTokenState.asSharedFlow()
+    private val regenerateTokenHandler: RegenerateTokenHandler
+) : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token broadcast received.")
-
-        val tokens = preferences.getTokens()
-
-        CoroutineScope(Dispatchers.IO).launch {
-
-            //Validation
-            tokens ?: run {
-                _regenerateTokenState.emit(
-                    TokenState(
-                        isError = true,
-                        error = KareError.INVALID_TOKEN
-                    )
-                )
-
-                return@launch
-            }
-
-            authenticationUseCases.regenerateTokenUseCase.invoke(tokens)
-                .collect { regenerateTokenState ->
-                    Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token state received. State: $regenerateTokenState")
-                    _regenerateTokenState.emit(regenerateTokenState)
-
-                    if (regenerateTokenState.isSuccessful) {
-                        Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token successfully done!")
-
-                        //Update preferences with new auth tokens
-                        preferences.updateTokens(regenerateTokenState.tokens)
-                    } else if (regenerateTokenState.isError) {
-                        Log.d("RegenerateTokenBroadcastReceiver", "Regenerate token failed!")
-                        Log.d("RegenerateTokenBroadcastReceiver", "Logging out...")
-
-                        //Delete existing auth tokens
-                        preferences.deleteTokens()
-                    }
-                }
-        }
+        regenerateTokenHandler.regenerateToken()
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
@@ -12,11 +12,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Provider
 
 class RegenerateTokenHandler @Inject constructor(
-    private val authenticationUseCases: AuthenticationUseCases,
+    private val authenticationUseCases: Provider<AuthenticationUseCases>,
     private val tokenDataStore: TokenDataStore
-): RegenerateTokenNotifier {
+) : RegenerateTokenNotifier {
 
     private val _regenerateTokenState = MutableSharedFlow<TokenState>(replay = 1)
     override val regenerateTokenState: Flow<TokenState> = _regenerateTokenState.asSharedFlow()
@@ -39,7 +40,7 @@ class RegenerateTokenHandler @Inject constructor(
                 return@launch
             }
 
-            authenticationUseCases.regenerateTokenUseCase.invoke(tokens)
+            authenticationUseCases.get().regenerateTokenUseCase.invoke(tokens)
                 .collect { regenerateTokenState ->
                     Log.d(
                         "RegenerateTokenHandler",

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
@@ -1,7 +1,7 @@
 package com.koleff.kare_android.common.broadcast
 
 import android.util.Log
-import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.common.preferences.TokenDataStore
 import com.koleff.kare_android.data.model.response.base_response.KareError
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import com.koleff.kare_android.ui.state.TokenState
@@ -15,7 +15,7 @@ import javax.inject.Inject
 
 class RegenerateTokenHandler @Inject constructor(
     private val authenticationUseCases: AuthenticationUseCases,
-    private val preferences: Preferences
+    private val tokenDataStore: TokenDataStore
 ): RegenerateTokenNotifier {
 
     private val _regenerateTokenState = MutableSharedFlow<TokenState>(replay = 1)
@@ -23,7 +23,7 @@ class RegenerateTokenHandler @Inject constructor(
     fun regenerateToken() {
         Log.d("RegenerateTokenHandler", "Regenerate token handler received.")
 
-        val tokens = preferences.getTokens()
+        val tokens = tokenDataStore.getTokens()
 
         CoroutineScope(Dispatchers.IO).launch {
 
@@ -54,13 +54,13 @@ class RegenerateTokenHandler @Inject constructor(
                         )
 
                         //Update preferences with new auth tokens
-                        preferences.updateTokens(regenerateTokenState.tokens)
+                        tokenDataStore.updateTokens(regenerateTokenState.tokens)
                     } else if (regenerateTokenState.isError) {
                         Log.d("RegenerateTokenHandler", "Regenerate token failed!")
                         Log.d("RegenerateTokenHandler", "Logging out...")
 
                         //Delete existing auth tokens
-                        preferences.deleteTokens()
+                        tokenDataStore.deleteTokens()
                     }
                 }
         }

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
@@ -12,10 +12,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Singleton
 
-//TODO: remove dependencies causing circular dependency...
-@Singleton
 class RegenerateTokenHandler @Inject constructor(
     private val authenticationUseCases: AuthenticationUseCases,
     private val preferences: Preferences

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenHandler.kt
@@ -1,0 +1,71 @@
+package com.koleff.kare_android.common.broadcast
+
+import android.util.Log
+import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.data.model.response.base_response.KareError
+import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
+import com.koleff.kare_android.ui.state.TokenState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+//TODO: remove dependencies causing circular dependency...
+@Singleton
+class RegenerateTokenHandler @Inject constructor(
+    private val authenticationUseCases: AuthenticationUseCases,
+    private val preferences: Preferences
+): RegenerateTokenNotifier {
+
+    private val _regenerateTokenState = MutableSharedFlow<TokenState>(replay = 1)
+    override val regenerateTokenState: Flow<TokenState> = _regenerateTokenState.asSharedFlow()
+    fun regenerateToken() {
+        Log.d("RegenerateTokenHandler", "Regenerate token handler received.")
+
+        val tokens = preferences.getTokens()
+
+        CoroutineScope(Dispatchers.IO).launch {
+
+            //Validation
+            tokens ?: run {
+                _regenerateTokenState.emit(
+                    TokenState(
+                        isError = true,
+                        error = KareError.INVALID_TOKEN
+                    )
+                )
+
+                return@launch
+            }
+
+            authenticationUseCases.regenerateTokenUseCase.invoke(tokens)
+                .collect { regenerateTokenState ->
+                    Log.d(
+                        "RegenerateTokenHandler",
+                        "Regenerate token state received. State: $regenerateTokenState"
+                    )
+                    _regenerateTokenState.emit(regenerateTokenState)
+
+                    if (regenerateTokenState.isSuccessful) {
+                        Log.d(
+                            "RegenerateTokenHandler",
+                            "Regenerate token successfully done!"
+                        )
+
+                        //Update preferences with new auth tokens
+                        preferences.updateTokens(regenerateTokenState.tokens)
+                    } else if (regenerateTokenState.isError) {
+                        Log.d("RegenerateTokenHandler", "Regenerate token failed!")
+                        Log.d("RegenerateTokenHandler", "Logging out...")
+
+                        //Delete existing auth tokens
+                        preferences.deleteTokens()
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenNotifier.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/broadcast/RegenerateTokenNotifier.kt
@@ -1,8 +1,10 @@
-package com.koleff.kare_android.common.network
+package com.koleff.kare_android.common.broadcast
 
 import com.koleff.kare_android.ui.state.TokenState
 import kotlinx.coroutines.flow.Flow
 
 interface RegenerateTokenNotifier {
     val regenerateTokenState: Flow<TokenState>
+
+    //suspend fun notifyTokenRegenerationResult(result: ResultWrapper<Boolean>)
 }

--- a/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
@@ -6,39 +6,12 @@ import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.multidex.BuildConfig
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.koleff.kare_android.common.Constants
-import com.koleff.kare_android.common.Constants.useLocalDataSource
 import com.koleff.kare_android.common.network.NetworkManager
 import com.koleff.kare_android.common.network.RegenerateTokenNotifier
 import com.koleff.kare_android.common.network.UUIDJsonAdapter
 import com.koleff.kare_android.common.preferences.DefaultPreferences
 import com.koleff.kare_android.common.preferences.Preferences
-import com.koleff.kare_android.data.datasource.DashboardDataSource
-import com.koleff.kare_android.data.datasource.DashboardMockupDataSource
-import com.koleff.kare_android.data.datasource.DoWorkoutDataSource
-import com.koleff.kare_android.data.datasource.DoWorkoutLocalDataSource
-import com.koleff.kare_android.data.datasource.DoWorkoutPerformanceMetricsDataSource
-import com.koleff.kare_android.data.datasource.DoWorkoutPerformanceMetricsLocalDataSource
-import com.koleff.kare_android.data.datasource.ExerciseDataSource
-import com.koleff.kare_android.data.datasource.ExerciseLocalDataSourceV2
-import com.koleff.kare_android.data.datasource.ExerciseRemoteDataSource
-import com.koleff.kare_android.data.datasource.UserDataSource
-import com.koleff.kare_android.data.datasource.UserLocalDataSource
-import com.koleff.kare_android.data.datasource.UserRemoteDataSource
-import com.koleff.kare_android.data.datasource.WorkoutDataSource
-import com.koleff.kare_android.data.datasource.WorkoutLocalDataSourceV2
-import com.koleff.kare_android.data.datasource.WorkoutRemoteDataSource
-import com.koleff.kare_android.data.remote.AuthenticationApi
-import com.koleff.kare_android.data.remote.ExerciseApi
-import com.koleff.kare_android.data.remote.UserApi
-import com.koleff.kare_android.data.remote.WorkoutApi
-import com.koleff.kare_android.data.repository.DashboardRepositoryImpl
-import com.koleff.kare_android.data.repository.DoWorkoutPerformanceMetricsRepositoryImpl
-import com.koleff.kare_android.data.repository.DoWorkoutRepositoryImpl
-import com.koleff.kare_android.data.repository.ExerciseRepositoryImpl
-import com.koleff.kare_android.data.repository.UserRepositoryImpl
-import com.koleff.kare_android.data.repository.WorkoutRepositoryImpl
 import com.koleff.kare_android.data.room.dao.DoWorkoutExerciseSetDao
 import com.koleff.kare_android.data.room.dao.DoWorkoutPerformanceMetricsDao
 import com.koleff.kare_android.data.room.dao.ExerciseDao
@@ -52,60 +25,6 @@ import com.koleff.kare_android.data.room.database.KareDatabase
 import com.koleff.kare_android.data.room.manager.ExerciseDBManagerV2
 import com.koleff.kare_android.data.room.manager.UserDBManager
 import com.koleff.kare_android.data.room.manager.WorkoutDBManagerV2
-import com.koleff.kare_android.domain.repository.DashboardRepository
-import com.koleff.kare_android.domain.repository.DoWorkoutPerformanceMetricsRepository
-import com.koleff.kare_android.domain.repository.DoWorkoutRepository
-import com.koleff.kare_android.domain.repository.ExerciseRepository
-import com.koleff.kare_android.domain.repository.UserRepository
-import com.koleff.kare_android.domain.repository.WorkoutRepository
-import com.koleff.kare_android.domain.usecases.AddExerciseUseCase
-import com.koleff.kare_android.domain.usecases.AddMultipleExercisesUseCase
-import com.koleff.kare_android.domain.usecases.AddNewExerciseSetUseCase
-import com.koleff.kare_android.domain.usecases.CreateCustomWorkoutDetailsUseCase
-import com.koleff.kare_android.domain.usecases.CreateCustomWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.CreateNewWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.CreateWorkoutConfigurationUseCase
-import com.koleff.kare_android.domain.usecases.DeleteDoWorkoutPerformanceMetricsUseCase
-import com.koleff.kare_android.domain.usecases.DeleteExerciseSetUseCase
-import com.koleff.kare_android.domain.usecases.DeleteExerciseUseCase
-import com.koleff.kare_android.domain.usecases.DeleteMultipleExercisesUseCase
-import com.koleff.kare_android.domain.usecases.DeleteWorkoutConfigurationUseCase
-import com.koleff.kare_android.domain.usecases.DeleteWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.DoWorkoutInitialSetupUseCase
-import com.koleff.kare_android.domain.usecases.DoWorkoutPerformanceMetricsUseCases
-import com.koleff.kare_android.domain.usecases.DoWorkoutUseCases
-import com.koleff.kare_android.domain.usecases.ExerciseUseCases
-import com.koleff.kare_android.domain.usecases.FavoriteWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.FindDuplicateExercisesUseCase
-import com.koleff.kare_android.domain.usecases.GetAllDoWorkoutPerformanceMetricsUseCase
-import com.koleff.kare_android.domain.usecases.GetAllWorkoutDetailsUseCase
-import com.koleff.kare_android.domain.usecases.GetAllWorkoutsUseCase
-import com.koleff.kare_android.domain.usecases.GetCatalogExerciseUseCase
-import com.koleff.kare_android.domain.usecases.GetCatalogExercisesUseCase
-import com.koleff.kare_android.domain.usecases.GetDoWorkoutPerformanceMetricsUseCase
-import com.koleff.kare_android.domain.usecases.GetExerciseDetailsUseCase
-import com.koleff.kare_android.domain.usecases.GetExerciseUseCase
-import com.koleff.kare_android.domain.usecases.GetFavoriteWorkoutsUseCase
-import com.koleff.kare_android.domain.usecases.GetWorkoutConfigurationUseCase
-import com.koleff.kare_android.domain.usecases.GetWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.GetWorkoutsDetailsUseCase
-import com.koleff.kare_android.domain.usecases.OnFilterExercisesUseCase
-import com.koleff.kare_android.domain.usecases.OnSearchExerciseUseCase
-import com.koleff.kare_android.domain.usecases.OnSearchWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.ResetTimerUseCase
-import com.koleff.kare_android.domain.usecases.SaveAllDoWorkoutExerciseSetUseCase
-import com.koleff.kare_android.domain.usecases.SaveDoWorkoutExerciseSetUseCase
-import com.koleff.kare_android.domain.usecases.SaveDoWorkoutPerformanceMetricsUseCase
-import com.koleff.kare_android.domain.usecases.StartTimerUseCase
-import com.koleff.kare_android.domain.usecases.SubmitExerciseUseCase
-import com.koleff.kare_android.domain.usecases.SubmitMultipleExercisesUseCase
-import com.koleff.kare_android.domain.usecases.UnfavoriteWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.UpdateDoWorkoutPerformanceMetricsUseCase
-import com.koleff.kare_android.domain.usecases.UpdateExerciseSetsAfterTimerUseCase
-import com.koleff.kare_android.domain.usecases.UpdateWorkoutConfigurationUseCase
-import com.koleff.kare_android.domain.usecases.UpdateWorkoutDetailsUseCase
-import com.koleff.kare_android.domain.usecases.UpdateWorkoutUseCase
-import com.koleff.kare_android.domain.usecases.WorkoutUseCases
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -113,12 +32,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
 @Module
@@ -179,62 +95,6 @@ object AppModule {
             .add(KotlinJsonAdapterFactory())
             .add(UUIDJsonAdapter())
             .build()
-    }
-
-    /**
-     * APIs
-     */
-
-    @Provides
-    @Singleton
-    fun provideExerciseApi(okHttpClient: OkHttpClient, moshi: Moshi): ExerciseApi {
-        return Retrofit.Builder()
-            .baseUrl(Constants.BASE_URL_FULL)
-            .client(okHttpClient)
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
-//            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(ExerciseApi::class.java)
-    }
-
-    @Provides
-    @Singleton
-    fun provideWorkoutApi(okHttpClient: OkHttpClient, moshi: Moshi): WorkoutApi {
-        return Retrofit.Builder()
-            .baseUrl(Constants.BASE_URL_FULL)
-            .client(okHttpClient)
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
-//            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(WorkoutApi::class.java)
-    }
-
-    @Provides
-    @Singleton
-    fun provideAuthenticationApi(okHttpClient: OkHttpClient, moshi: Moshi): AuthenticationApi {
-        return Retrofit.Builder()
-            .baseUrl(Constants.BASE_URL_FULL)
-            .client(okHttpClient)
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
-//            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(AuthenticationApi::class.java)
-    }
-
-    @Provides
-    @Singleton
-    fun provideUserApi(okHttpClient: OkHttpClient, moshi: Moshi): UserApi {
-        return Retrofit.Builder()
-            .baseUrl(Constants.BASE_URL_FULL)
-            .client(okHttpClient)
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
-//            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(UserApi::class.java)
     }
 
     /**
@@ -369,244 +229,9 @@ object AppModule {
     }
 
     /**
-     * Data sources
-     */
-
-    @Provides
-    @Singleton
-    fun provideExerciseDataSource(
-        exerciseApi: ExerciseApi,
-        exerciseDao: ExerciseDao,
-        exerciseDetailsDao: ExerciseDetailsDao,
-        exerciseSetDao: ExerciseSetDao,
-        networkManager: NetworkManager
-    ): ExerciseDataSource {
-        return if (useLocalDataSource) ExerciseLocalDataSourceV2(
-            exerciseDao = exerciseDao,
-            exerciseDetailsDao = exerciseDetailsDao,
-            exerciseSetDao = exerciseSetDao
-        )
-        else ExerciseRemoteDataSource(
-            exerciseApi = exerciseApi,
-            networkManager = networkManager
-        )
-    }
-
-
-    @Provides
-    @Singleton
-    fun provideWorkoutDataSource(
-        workoutApi: WorkoutApi,
-        workoutDao: WorkoutDao,
-        exerciseDao: ExerciseDao,
-        workoutDetailsDao: WorkoutDetailsDao,
-        exerciseSetDao: ExerciseSetDao,
-        workoutConfigurationDao: WorkoutConfigurationDao,
-        networkManager: NetworkManager,
-        @IoDispatcher dispatcher: CoroutineDispatcher
-    ): WorkoutDataSource {
-        return if (useLocalDataSource) WorkoutLocalDataSourceV2(
-            workoutDao = workoutDao,
-            exerciseDao = exerciseDao,
-            workoutDetailsDao = workoutDetailsDao,
-            exerciseSetDao = exerciseSetDao,
-            workoutConfigurationDao = workoutConfigurationDao
-
-        )
-        else WorkoutRemoteDataSource(
-            workoutApi = workoutApi,
-            networkManager = networkManager,
-            dispatcher = dispatcher
-        )
-    }
-
-    @Provides
-    @Singleton
-    fun provideDashboardDataSource(): DashboardDataSource {
-        return DashboardMockupDataSource()
-    }
-
-    @Provides
-    @Singleton
-    fun provideUserDataSource(
-        userDao: UserDao,
-        userApi: UserApi,
-        networkManager: NetworkManager,
-        @IoDispatcher dispatcher: CoroutineDispatcher
-    ): UserDataSource {
-        return if (useLocalDataSource) UserLocalDataSource(
-            userDao = userDao
-        )
-        else UserRemoteDataSource(
-            userApi = userApi,
-            networkManager = networkManager,
-            dispatcher = dispatcher
-        )
-    }
-
-    @Provides
-    @Singleton
-    fun provideDoWorkoutDataSource(): DoWorkoutDataSource {
-        return DoWorkoutLocalDataSource() //Local for now...
-    }
-
-    @Provides
-    @Singleton
-    fun provideDoWorkoutPerformanceMetricsDataSource(
-        doWorkoutPerformanceMetricsDao: DoWorkoutPerformanceMetricsDao,
-        doWorkoutExerciseSetDao: DoWorkoutExerciseSetDao
-    ): DoWorkoutPerformanceMetricsDataSource {
-        return DoWorkoutPerformanceMetricsLocalDataSource(
-            doWorkoutPerformanceMetricsDao = doWorkoutPerformanceMetricsDao,
-            doWorkoutExerciseSetDao = doWorkoutExerciseSetDao
-        ) //Local for now...
-    }
-
-
-    /**
-     * Repositories
-     */
-
-    @Provides
-    @Singleton
-    fun provideWorkoutRepository(workoutDataSource: WorkoutDataSource): WorkoutRepository {
-        return WorkoutRepositoryImpl(workoutDataSource)
-    }
-
-    @Provides
-    @Singleton
-    fun provideDashboardRepository(dashboardDataSource: DashboardDataSource): DashboardRepository {
-        return DashboardRepositoryImpl(dashboardDataSource)
-    }
-
-    @Provides
-    @Singleton
-    fun provideExerciseRepository(exerciseDataSource: ExerciseDataSource): ExerciseRepository {
-        return ExerciseRepositoryImpl(exerciseDataSource)
-    }
-
-    @Provides
-    @Singleton
-    fun provideUserRepository(userDataSource: UserDataSource): UserRepository {
-        return UserRepositoryImpl(userDataSource)
-    }
-
-    @Provides
-    @Singleton
-    fun provideDoWorkoutRepository(doWorkoutDataSource: DoWorkoutDataSource): DoWorkoutRepository {
-        return DoWorkoutRepositoryImpl(doWorkoutDataSource)
-    }
-
-    @Provides
-    @Singleton
-    fun provideDoWorkoutPerformanceMetricsRepository(doWorkoutPerformanceMetricsDataSource: DoWorkoutPerformanceMetricsDataSource)
-            : DoWorkoutPerformanceMetricsRepository {
-        return DoWorkoutPerformanceMetricsRepositoryImpl(doWorkoutPerformanceMetricsDataSource)
-    }
-
-    /**
-     * Use Cases
-     */
-
-    @Provides
-    @Singleton
-    fun provideWorkoutUseCases(workoutRepository: WorkoutRepository): WorkoutUseCases {
-        return WorkoutUseCases(
-            getWorkoutDetailsUseCase = GetWorkoutsDetailsUseCase(workoutRepository),
-            getAllWorkoutsUseCase = GetAllWorkoutsUseCase(workoutRepository),
-            getAllWorkoutDetailsUseCase = GetAllWorkoutDetailsUseCase(workoutRepository),
-            getWorkoutUseCase = GetWorkoutUseCase(workoutRepository),
-            updateWorkoutUseCase = UpdateWorkoutUseCase(workoutRepository),
-            updateWorkoutDetailsUseCase = UpdateWorkoutDetailsUseCase(workoutRepository),
-            onSearchWorkoutUseCase = OnSearchWorkoutUseCase(),
-            deleteExerciseUseCase = DeleteExerciseUseCase(workoutRepository),
-            deleteMultipleExercisesUseCase = DeleteMultipleExercisesUseCase(workoutRepository),
-            addExerciseUseCase = AddExerciseUseCase(workoutRepository),
-            addMultipleExercisesUseCase = AddMultipleExercisesUseCase(workoutRepository),
-            submitExerciseUseCase = SubmitExerciseUseCase(workoutRepository),
-            submitMultipleExercisesUseCase = SubmitMultipleExercisesUseCase(workoutRepository),
-            findDuplicateExercisesUseCase = FindDuplicateExercisesUseCase(workoutRepository),
-            deleteWorkoutUseCase = DeleteWorkoutUseCase(workoutRepository),
-            favoriteWorkoutUseCase = FavoriteWorkoutUseCase(workoutRepository),
-            unfavoriteWorkoutUseCase = UnfavoriteWorkoutUseCase(workoutRepository),
-            getFavoriteWorkoutsUseCase = GetFavoriteWorkoutsUseCase(workoutRepository),
-            createNewWorkoutUseCase = CreateNewWorkoutUseCase(workoutRepository),
-            createCustomWorkoutUseCase = CreateCustomWorkoutUseCase(workoutRepository),
-            createCustomWorkoutDetailsUseCase = CreateCustomWorkoutDetailsUseCase(workoutRepository),
-            getWorkoutConfigurationUseCase = GetWorkoutConfigurationUseCase(workoutRepository),
-            createWorkoutConfigurationUseCase = CreateWorkoutConfigurationUseCase(workoutRepository),
-            updateWorkoutConfigurationUseCase = UpdateWorkoutConfigurationUseCase(workoutRepository),
-            deleteWorkoutConfigurationUseCase = DeleteWorkoutConfigurationUseCase(workoutRepository)
-        )
-    }
-
-    @Provides
-    @Singleton
-    fun provideExerciseUseCases(exerciseRepository: ExerciseRepository): ExerciseUseCases {
-        return ExerciseUseCases(
-            onSearchExerciseUseCase = OnSearchExerciseUseCase(),
-            onFilterExercisesUseCase = OnFilterExercisesUseCase(),
-            getExerciseDetailsUseCase = GetExerciseDetailsUseCase(exerciseRepository),
-            getCatalogExercisesUseCase = GetCatalogExercisesUseCase(exerciseRepository),
-            getCatalogExerciseUseCase = GetCatalogExerciseUseCase(exerciseRepository),
-            deleteExerciseSetUseCase = DeleteExerciseSetUseCase(exerciseRepository),
-            addNewExerciseSetUseCase = AddNewExerciseSetUseCase(exerciseRepository),
-            getExerciseUseCase = GetExerciseUseCase(exerciseRepository)
-        )
-    }
-
-    @Provides
-    @Singleton
-    fun provideDoWorkoutUseCases(
-        doWorkoutRepository: DoWorkoutRepository,
-        exerciseRepository: ExerciseRepository
-    ): DoWorkoutUseCases {
-        return DoWorkoutUseCases(
-            doWorkoutInitialSetupUseCase = DoWorkoutInitialSetupUseCase(doWorkoutRepository),
-            updateExerciseSetsAfterTimerUseCase = UpdateExerciseSetsAfterTimerUseCase(
-                doWorkoutRepository
-            ),
-            addNewExerciseSetUseCase = AddNewExerciseSetUseCase(exerciseRepository),
-            deleteExerciseSetUseCase = DeleteExerciseSetUseCase(exerciseRepository),
-            startTimerUseCase = StartTimerUseCase(),
-            resetTimerUseCase = ResetTimerUseCase()
-        )
-    }
-
-
-    @Provides
-    @Singleton
-    fun provideDoWorkoutPerformanceMetricsUseCases(
-        doWorkoutPerformanceMetricsRepository: DoWorkoutPerformanceMetricsRepository
-    ): DoWorkoutPerformanceMetricsUseCases {
-        return DoWorkoutPerformanceMetricsUseCases(
-            deleteDoWorkoutPerformanceMetricsUseCase = DeleteDoWorkoutPerformanceMetricsUseCase(
-                doWorkoutPerformanceMetricsRepository
-            ),
-            updateDoWorkoutPerformanceMetricsUseCase = UpdateDoWorkoutPerformanceMetricsUseCase(
-                doWorkoutPerformanceMetricsRepository
-            ),
-            getAllDoWorkoutPerformanceMetricsUseCase = GetAllDoWorkoutPerformanceMetricsUseCase(
-                doWorkoutPerformanceMetricsRepository
-            ),
-            getDoWorkoutPerformanceMetricsUseCase = GetDoWorkoutPerformanceMetricsUseCase(
-                doWorkoutPerformanceMetricsRepository
-            ),
-            saveAllDoWorkoutExerciseSetUseCase = SaveAllDoWorkoutExerciseSetUseCase(
-                doWorkoutPerformanceMetricsRepository
-            ),
-            saveDoWorkoutExerciseSetUseCase = SaveDoWorkoutExerciseSetUseCase(
-                doWorkoutPerformanceMetricsRepository
-            ),
-            saveDoWorkoutPerformanceMetricsUseCase = SaveDoWorkoutPerformanceMetricsUseCase(
-                doWorkoutPerformanceMetricsRepository
-            )
-        )
-    }
-
-    /**
      * Shared preferences
      */
+
     @Provides
     @Singleton
     fun provideSharedPreferences(

--- a/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
@@ -10,6 +10,7 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import com.koleff.kare_android.common.Constants
 import com.koleff.kare_android.common.Constants.useLocalDataSource
 import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.RegenerateTokenNotifier
 import com.koleff.kare_android.common.network.UUIDJsonAdapter
 import com.koleff.kare_android.common.preferences.DefaultPreferences
 import com.koleff.kare_android.common.preferences.Preferences
@@ -579,13 +580,27 @@ object AppModule {
         doWorkoutPerformanceMetricsRepository: DoWorkoutPerformanceMetricsRepository
     ): DoWorkoutPerformanceMetricsUseCases {
         return DoWorkoutPerformanceMetricsUseCases(
-            deleteDoWorkoutPerformanceMetricsUseCase = DeleteDoWorkoutPerformanceMetricsUseCase(doWorkoutPerformanceMetricsRepository),
-            updateDoWorkoutPerformanceMetricsUseCase = UpdateDoWorkoutPerformanceMetricsUseCase(doWorkoutPerformanceMetricsRepository),
-            getAllDoWorkoutPerformanceMetricsUseCase = GetAllDoWorkoutPerformanceMetricsUseCase(doWorkoutPerformanceMetricsRepository),
-            getDoWorkoutPerformanceMetricsUseCase = GetDoWorkoutPerformanceMetricsUseCase(doWorkoutPerformanceMetricsRepository),
-            saveAllDoWorkoutExerciseSetUseCase = SaveAllDoWorkoutExerciseSetUseCase(doWorkoutPerformanceMetricsRepository),
-            saveDoWorkoutExerciseSetUseCase = SaveDoWorkoutExerciseSetUseCase(doWorkoutPerformanceMetricsRepository),
-            saveDoWorkoutPerformanceMetricsUseCase = SaveDoWorkoutPerformanceMetricsUseCase(doWorkoutPerformanceMetricsRepository)
+            deleteDoWorkoutPerformanceMetricsUseCase = DeleteDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            updateDoWorkoutPerformanceMetricsUseCase = UpdateDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            getAllDoWorkoutPerformanceMetricsUseCase = GetAllDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            getDoWorkoutPerformanceMetricsUseCase = GetDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            saveAllDoWorkoutExerciseSetUseCase = SaveAllDoWorkoutExerciseSetUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            saveDoWorkoutExerciseSetUseCase = SaveDoWorkoutExerciseSetUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            saveDoWorkoutPerformanceMetricsUseCase = SaveDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            )
         )
     }
 
@@ -612,7 +627,23 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideNetworkManager(): NetworkManager {
-        return NetworkManager()
+    fun provideNetworkManager(
+        broadcastManager: LocalBroadcastManager,
+        regenerateTokenNotifier: RegenerateTokenNotifier
+    ): NetworkManager {
+        return NetworkManager(
+            broadcastManager = broadcastManager,
+            regenerateTokenNotifier = regenerateTokenNotifier
+        )
+    }
+
+    /**
+     * Broadcast manager
+     */
+
+    @Provides
+    @Singleton
+    fun provideLocalBroadcastManager(@ApplicationContext context: Context): LocalBroadcastManager {
+        return LocalBroadcastManager.getInstance(context)
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
@@ -7,7 +7,6 @@ import android.content.SharedPreferences
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.multidex.BuildConfig
 import com.koleff.kare_android.common.network.BearerTokenInterceptor
-import com.koleff.kare_android.common.network.RegenerateTokenInterceptor
 import com.koleff.kare_android.common.network.UUIDJsonAdapter
 import com.koleff.kare_android.common.preferences.DefaultPreferences
 import com.koleff.kare_android.common.preferences.Preferences
@@ -46,12 +45,11 @@ object AppModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(
-        bearerTokenInterceptor: BearerTokenInterceptor,
-        regenerateTokenInterceptor: RegenerateTokenInterceptor
+        bearerTokenInterceptor: BearerTokenInterceptor
     ): OkHttpClient {
         val okHttpClientBuilder = OkHttpClient.Builder()
             .addInterceptor(bearerTokenInterceptor)
-            .addInterceptor(regenerateTokenInterceptor)
+//            .addInterceptor(regenerateTokenInterceptor)
 
         //Logging
         val logging = HttpLoggingInterceptor()

--- a/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
@@ -7,8 +7,6 @@ import android.content.SharedPreferences
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.multidex.BuildConfig
 import com.koleff.kare_android.common.Constants
-import com.koleff.kare_android.common.network.NetworkManager
-import com.koleff.kare_android.common.network.RegenerateTokenNotifier
 import com.koleff.kare_android.common.network.UUIDJsonAdapter
 import com.koleff.kare_android.common.preferences.DefaultPreferences
 import com.koleff.kare_android.common.preferences.Preferences
@@ -244,22 +242,6 @@ object AppModule {
     @Singleton
     fun providePreferences(sharedPreferences: SharedPreferences): Preferences {
         return DefaultPreferences(sharedPreferences)
-    }
-
-    /**
-     * Network
-     */
-
-    @Provides
-    @Singleton
-    fun provideNetworkManager(
-        broadcastManager: LocalBroadcastManager,
-        regenerateTokenNotifier: RegenerateTokenNotifier
-    ): NetworkManager {
-        return NetworkManager(
-            broadcastManager = broadcastManager,
-            regenerateTokenNotifier = regenerateTokenNotifier
-        )
     }
 
     /**

--- a/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
@@ -4,8 +4,8 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import com.koleff.kare_android.common.Constants
 import com.koleff.kare_android.common.auth.CredentialsAuthenticator
 import com.koleff.kare_android.common.auth.CredentialsAuthenticatorImpl
-import com.koleff.kare_android.common.auth.CredentialsDataStore
-import com.koleff.kare_android.common.auth.CredentialsDataStoreImpl
+import com.koleff.kare_android.common.preferences.CredentialsDataStore
+import com.koleff.kare_android.common.preferences.CredentialsDataStoreImpl
 import com.koleff.kare_android.common.auth.CredentialsValidator
 import com.koleff.kare_android.common.auth.CredentialsValidatorImpl
 import com.koleff.kare_android.common.network.NetworkManager

--- a/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
@@ -6,6 +6,7 @@ import com.koleff.kare_android.common.auth.CredentialsDataStore
 import com.koleff.kare_android.common.auth.CredentialsDataStoreImpl
 import com.koleff.kare_android.common.auth.CredentialsValidator
 import com.koleff.kare_android.common.auth.CredentialsValidatorImpl
+import com.koleff.kare_android.common.network.NetworkManager
 import com.koleff.kare_android.common.preferences.Preferences
 import com.koleff.kare_android.data.datasource.AuthenticationDataSource
 import com.koleff.kare_android.data.datasource.AuthenticationLocalDataSource
@@ -56,7 +57,8 @@ object AuthenticationModule {
     fun provideAuthenticationDataSource(
         authenticationApi: AuthenticationApi,
         userDao: UserDao,
-        credentialsAuthenticator: CredentialsAuthenticator
+        credentialsAuthenticator: CredentialsAuthenticator,
+        networkManager: NetworkManager
     ): AuthenticationDataSource {
         val useRemoteAPI = false //Temporary testing authentication with remote API and other functionalities with local impl.
 
@@ -64,7 +66,8 @@ object AuthenticationModule {
             userDao = userDao,
             credentialsAuthenticator = credentialsAuthenticator
         ) else AuthenticationRemoteDataSource(
-            authenticationApi = authenticationApi
+            authenticationApi = authenticationApi,
+            networkManager = networkManager
         )
     }
 

--- a/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
@@ -1,5 +1,7 @@
 package com.koleff.kare_android.common.di
 
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.koleff.kare_android.common.Constants
 import com.koleff.kare_android.common.auth.CredentialsAuthenticator
 import com.koleff.kare_android.common.auth.CredentialsAuthenticatorImpl
 import com.koleff.kare_android.common.auth.CredentialsDataStore
@@ -21,15 +23,40 @@ import com.koleff.kare_android.domain.usecases.LoginUseCase
 import com.koleff.kare_android.domain.usecases.LogoutUseCase
 import com.koleff.kare_android.domain.usecases.RegenerateTokenUseCase
 import com.koleff.kare_android.domain.usecases.RegisterUseCase
+import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object AuthenticationModule {
+
+    /**
+     * API
+     */
+
+    @Provides
+    @Singleton
+    fun provideAuthenticationApi(okHttpClient: OkHttpClient, moshi: Moshi): AuthenticationApi {
+        return Retrofit.Builder()
+            .baseUrl(Constants.BASE_URL_FULL)
+            .client(okHttpClient)
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+//            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(AuthenticationApi::class.java)
+    }
+
+    /**
+     * Components
+     */
 
     @Provides
     @Singleton
@@ -52,6 +79,10 @@ object AuthenticationModule {
         return CredentialsAuthenticatorImpl(credentialsValidator, credentialsDataStore)
     }
 
+    /**
+     * Data source
+     */
+
     @Provides
     @Singleton
     fun provideAuthenticationDataSource(
@@ -71,11 +102,19 @@ object AuthenticationModule {
         )
     }
 
+    /**
+     * Repository
+     */
+
     @Provides
     @Singleton
     fun provideAuthenticationRepository(authenticationDataSource: AuthenticationDataSource): AuthenticationRepository {
         return AuthenticationRepositoryImpl(authenticationDataSource)
     }
+
+    /**
+     * Use cases
+     */
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
@@ -4,11 +4,12 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import com.koleff.kare_android.common.Constants
 import com.koleff.kare_android.common.auth.CredentialsAuthenticator
 import com.koleff.kare_android.common.auth.CredentialsAuthenticatorImpl
-import com.koleff.kare_android.common.preferences.CredentialsDataStore
-import com.koleff.kare_android.common.preferences.CredentialsDataStoreImpl
 import com.koleff.kare_android.common.auth.CredentialsValidator
 import com.koleff.kare_android.common.auth.CredentialsValidatorImpl
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
+import com.koleff.kare_android.common.network.ApiCallWrapper
+import com.koleff.kare_android.common.preferences.CredentialsDataStore
+import com.koleff.kare_android.common.preferences.CredentialsDataStoreImpl
 import com.koleff.kare_android.common.preferences.Preferences
 import com.koleff.kare_android.data.datasource.AuthenticationDataSource
 import com.koleff.kare_android.data.datasource.AuthenticationLocalDataSource
@@ -89,16 +90,19 @@ object AuthenticationModule {
         authenticationApi: AuthenticationApi,
         userDao: UserDao,
         credentialsAuthenticator: CredentialsAuthenticator,
-        networkManager: NetworkManager
+        apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper,
+        apiCallWrapper: ApiCallWrapper
     ): AuthenticationDataSource {
-        val useRemoteAPI = false //Temporary testing authentication with remote API and other functionalities with local impl.
+        val useRemoteAPI =
+            false //Temporary testing authentication with remote API and other functionalities with local impl.
 
         return if (!useRemoteAPI) AuthenticationLocalDataSource(
             userDao = userDao,
             credentialsAuthenticator = credentialsAuthenticator
         ) else AuthenticationRemoteDataSource(
             authenticationApi = authenticationApi,
-            networkManager = networkManager
+            apiAuthorizationCallWrapper = apiAuthorizationCallWrapper,
+            apiCallWrapper = apiCallWrapper
         )
     }
 

--- a/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/AuthenticationModule.kt
@@ -1,6 +1,5 @@
 package com.koleff.kare_android.common.di
 
-import com.koleff.kare_android.common.Constants.useLocalDataSource
 import com.koleff.kare_android.common.auth.CredentialsAuthenticator
 import com.koleff.kare_android.common.auth.CredentialsAuthenticatorImpl
 import com.koleff.kare_android.common.auth.CredentialsDataStore
@@ -19,6 +18,7 @@ import com.koleff.kare_android.domain.repository.UserRepository
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import com.koleff.kare_android.domain.usecases.LoginUseCase
 import com.koleff.kare_android.domain.usecases.LogoutUseCase
+import com.koleff.kare_android.domain.usecases.RegenerateTokenUseCase
 import com.koleff.kare_android.domain.usecases.RegisterUseCase
 import dagger.Module
 import dagger.Provides
@@ -83,7 +83,8 @@ object AuthenticationModule {
         return AuthenticationUseCases(
             loginUseCase = LoginUseCase(authenticationRepository, credentialsAuthenticator),
             registerUseCase = RegisterUseCase(authenticationRepository, credentialsAuthenticator),
-            logoutUseCase = LogoutUseCase(authenticationRepository)
+            logoutUseCase = LogoutUseCase(authenticationRepository),
+            regenerateTokenUseCase = RegenerateTokenUseCase(authenticationRepository)
         )
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
@@ -1,7 +1,9 @@
 package com.koleff.kare_android.common.di
 
 import com.koleff.kare_android.common.broadcast.LogoutBroadcastReceiver
+import com.koleff.kare_android.common.broadcast.LogoutHandler
 import com.koleff.kare_android.common.broadcast.RegenerateTokenBroadcastReceiver
+import com.koleff.kare_android.common.broadcast.RegenerateTokenHandler
 import com.koleff.kare_android.common.navigation.NavigationController
 import com.koleff.kare_android.common.preferences.Preferences
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
@@ -18,24 +20,29 @@ object BroadcastReceiverModule {
     @Provides
     @Singleton
     fun provideRegenerateTokenBroadcastReceiver(
-        authenticationUseCases: AuthenticationUseCases,
-        preferences: Preferences
+        regenerateTokenHandler: RegenerateTokenHandler
     ): RegenerateTokenBroadcastReceiver {
         return RegenerateTokenBroadcastReceiver(
-            authenticationUseCases = authenticationUseCases,
-            preferences = preferences
+            regenerateTokenHandler = regenerateTokenHandler
         )
     }
-
 
     @Provides
     @Singleton
     fun provideLogoutBroadcastReceiver(
+        logoutHandler: LogoutHandler
+    ): LogoutBroadcastReceiver {
+       return LogoutBroadcastReceiver(logoutHandler)
+    }
+
+    @Provides
+    @Singleton
+    fun provideLogoutHandler(
         authenticationUseCases: AuthenticationUseCases,
         preferences: Preferences,
         navigationController: NavigationController
-    ): LogoutBroadcastReceiver {
-        return LogoutBroadcastReceiver(
+    ): LogoutHandler {
+        return LogoutHandler(
             authenticationUseCases = authenticationUseCases,
             preferences = preferences,
             navigationController = navigationController

--- a/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
@@ -11,6 +11,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module
@@ -38,7 +39,7 @@ object BroadcastReceiverModule {
     @Provides
     @Singleton
     fun provideLogoutHandler(
-        authenticationUseCases: AuthenticationUseCases,
+        authenticationUseCases: Provider<AuthenticationUseCases>,
         credentialsDataStore: CredentialsDataStore,
         navigationController: NavigationController
     ): LogoutHandler {

--- a/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
@@ -5,7 +5,7 @@ import com.koleff.kare_android.common.broadcast.LogoutHandler
 import com.koleff.kare_android.common.broadcast.RegenerateTokenBroadcastReceiver
 import com.koleff.kare_android.common.broadcast.RegenerateTokenHandler
 import com.koleff.kare_android.common.navigation.NavigationController
-import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.common.preferences.CredentialsDataStore
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import dagger.Module
 import dagger.Provides
@@ -39,12 +39,12 @@ object BroadcastReceiverModule {
     @Singleton
     fun provideLogoutHandler(
         authenticationUseCases: AuthenticationUseCases,
-        preferences: Preferences,
+        credentialsDataStore: CredentialsDataStore,
         navigationController: NavigationController
     ): LogoutHandler {
         return LogoutHandler(
             authenticationUseCases = authenticationUseCases,
-            preferences = preferences,
+            credentialsDataStore = credentialsDataStore,
             navigationController = navigationController
         )
     }

--- a/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/BroadcastReceiverModule.kt
@@ -1,0 +1,44 @@
+package com.koleff.kare_android.common.di
+
+import com.koleff.kare_android.common.broadcast.LogoutBroadcastReceiver
+import com.koleff.kare_android.common.broadcast.RegenerateTokenBroadcastReceiver
+import com.koleff.kare_android.common.navigation.NavigationController
+import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BroadcastReceiverModule {
+
+    @Provides
+    @Singleton
+    fun provideRegenerateTokenBroadcastReceiver(
+        authenticationUseCases: AuthenticationUseCases,
+        preferences: Preferences
+    ): RegenerateTokenBroadcastReceiver {
+        return RegenerateTokenBroadcastReceiver(
+            authenticationUseCases = authenticationUseCases,
+            preferences = preferences
+        )
+    }
+
+
+    @Provides
+    @Singleton
+    fun provideLogoutBroadcastReceiver(
+        authenticationUseCases: AuthenticationUseCases,
+        preferences: Preferences,
+        navigationController: NavigationController
+    ): LogoutBroadcastReceiver {
+        return LogoutBroadcastReceiver(
+            authenticationUseCases = authenticationUseCases,
+            preferences = preferences,
+            navigationController = navigationController
+        )
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/DashboardModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/DashboardModule.kt
@@ -1,0 +1,36 @@
+package com.koleff.kare_android.common.di
+
+import com.koleff.kare_android.data.datasource.DashboardDataSource
+import com.koleff.kare_android.data.datasource.DashboardMockupDataSource
+import com.koleff.kare_android.data.repository.DashboardRepositoryImpl
+import com.koleff.kare_android.domain.repository.DashboardRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DashboardModule {
+
+    /**
+     * Data sources
+     */
+
+    @Provides
+    @Singleton
+    fun provideDashboardDataSource(): DashboardDataSource {
+        return DashboardMockupDataSource()
+    }
+
+    /**
+     * Repositories
+     */
+
+    @Provides
+    @Singleton
+    fun provideDashboardRepository(dashboardDataSource: DashboardDataSource): DashboardRepository {
+        return DashboardRepositoryImpl(dashboardDataSource)
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/DoWorkoutModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/DoWorkoutModule.kt
@@ -1,0 +1,82 @@
+package com.koleff.kare_android.common.di
+
+import com.koleff.kare_android.data.datasource.DoWorkoutDataSource
+import com.koleff.kare_android.data.datasource.DoWorkoutLocalDataSource
+import com.koleff.kare_android.data.repository.DoWorkoutRepositoryImpl
+import com.koleff.kare_android.domain.repository.DoWorkoutRepository
+import com.koleff.kare_android.domain.repository.ExerciseRepository
+import com.koleff.kare_android.domain.usecases.AddNewExerciseSetUseCase
+import com.koleff.kare_android.domain.usecases.DeleteExerciseSetUseCase
+import com.koleff.kare_android.domain.usecases.DoWorkoutInitialSetupUseCase
+import com.koleff.kare_android.domain.usecases.DoWorkoutUseCases
+import com.koleff.kare_android.domain.usecases.ResetTimerUseCase
+import com.koleff.kare_android.domain.usecases.StartTimerUseCase
+import com.koleff.kare_android.domain.usecases.UpdateExerciseSetsAfterTimerUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DoWorkoutModule {
+
+    /**
+     * API
+     */
+
+//    @Provides
+//    @Singleton
+//    fun provideDoWorkoutApi(okHttpClient: OkHttpClient, moshi: Moshi): UserApi {
+//        return Retrofit.Builder()
+//            .baseUrl(Constants.BASE_URL_FULL)
+//            .client(okHttpClient)
+//            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+//            .addConverterFactory(MoshiConverterFactory.create(moshi))
+////            .addConverterFactory(GsonConverterFactory.create())
+//            .build()
+//            .create(DoWorkoutApi::class.java)
+//    }
+
+    /**
+     * Data source
+     */
+    @Provides
+    @Singleton
+    fun provideDoWorkoutDataSource(): DoWorkoutDataSource {
+        return DoWorkoutLocalDataSource() //Local for now...
+    }
+
+
+    /**
+     * Repository
+     */
+    @Provides
+    @Singleton
+    fun provideDoWorkoutRepository(doWorkoutDataSource: DoWorkoutDataSource): DoWorkoutRepository {
+        return DoWorkoutRepositoryImpl(doWorkoutDataSource)
+    }
+
+    /**
+     * Use Cases
+     */
+
+    @Provides
+    @Singleton
+    fun provideDoWorkoutUseCases(
+        doWorkoutRepository: DoWorkoutRepository,
+        exerciseRepository: ExerciseRepository
+    ): DoWorkoutUseCases {
+        return DoWorkoutUseCases(
+            doWorkoutInitialSetupUseCase = DoWorkoutInitialSetupUseCase(doWorkoutRepository),
+            updateExerciseSetsAfterTimerUseCase = UpdateExerciseSetsAfterTimerUseCase(
+                doWorkoutRepository
+            ),
+            addNewExerciseSetUseCase = AddNewExerciseSetUseCase(exerciseRepository),
+            deleteExerciseSetUseCase = DeleteExerciseSetUseCase(exerciseRepository),
+            startTimerUseCase = StartTimerUseCase(),
+            resetTimerUseCase = ResetTimerUseCase()
+        )
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/DoWorkoutPerformanceMetricsModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/DoWorkoutPerformanceMetricsModule.kt
@@ -1,0 +1,104 @@
+package com.koleff.kare_android.common.di
+
+import com.koleff.kare_android.data.datasource.DoWorkoutPerformanceMetricsDataSource
+import com.koleff.kare_android.data.datasource.DoWorkoutPerformanceMetricsLocalDataSource
+import com.koleff.kare_android.data.repository.DoWorkoutPerformanceMetricsRepositoryImpl
+import com.koleff.kare_android.data.room.dao.DoWorkoutExerciseSetDao
+import com.koleff.kare_android.data.room.dao.DoWorkoutPerformanceMetricsDao
+import com.koleff.kare_android.domain.repository.DoWorkoutPerformanceMetricsRepository
+import com.koleff.kare_android.domain.usecases.DeleteDoWorkoutPerformanceMetricsUseCase
+import com.koleff.kare_android.domain.usecases.DoWorkoutPerformanceMetricsUseCases
+import com.koleff.kare_android.domain.usecases.GetAllDoWorkoutPerformanceMetricsUseCase
+import com.koleff.kare_android.domain.usecases.GetDoWorkoutPerformanceMetricsUseCase
+import com.koleff.kare_android.domain.usecases.SaveAllDoWorkoutExerciseSetUseCase
+import com.koleff.kare_android.domain.usecases.SaveDoWorkoutExerciseSetUseCase
+import com.koleff.kare_android.domain.usecases.SaveDoWorkoutPerformanceMetricsUseCase
+import com.koleff.kare_android.domain.usecases.UpdateDoWorkoutPerformanceMetricsUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DoWorkoutPerformanceMetricsModule {
+
+    /**
+     * API
+     */
+
+//    @Provides
+//    @Singleton
+//    fun provideDoWorkoutPerformanceMetricsApi(okHttpClient: OkHttpClient, moshi: Moshi): UserApi {
+//        return Retrofit.Builder()
+//            .baseUrl(Constants.BASE_URL_FULL)
+//            .client(okHttpClient)
+//            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+//            .addConverterFactory(MoshiConverterFactory.create(moshi))
+////            .addConverterFactory(GsonConverterFactory.create())
+//            .build()
+//            .create(DoWorkoutPerformanceMetricsApi::class.java)
+//    }
+
+    /**
+     * Data source
+     */
+
+    @Provides
+    @Singleton
+    fun provideDoWorkoutPerformanceMetricsDataSource(
+        doWorkoutPerformanceMetricsDao: DoWorkoutPerformanceMetricsDao,
+        doWorkoutExerciseSetDao: DoWorkoutExerciseSetDao
+    ): DoWorkoutPerformanceMetricsDataSource {
+        return DoWorkoutPerformanceMetricsLocalDataSource(
+            doWorkoutPerformanceMetricsDao = doWorkoutPerformanceMetricsDao,
+            doWorkoutExerciseSetDao = doWorkoutExerciseSetDao
+        ) //Local for now...
+    }
+
+    /**
+     * Repository
+     */
+
+    @Provides
+    @Singleton
+    fun provideDoWorkoutPerformanceMetricsRepository(doWorkoutPerformanceMetricsDataSource: DoWorkoutPerformanceMetricsDataSource)
+            : DoWorkoutPerformanceMetricsRepository {
+        return DoWorkoutPerformanceMetricsRepositoryImpl(doWorkoutPerformanceMetricsDataSource)
+    }
+
+    /**
+     * Use cases
+     */
+
+    @Provides
+    @Singleton
+    fun provideDoWorkoutPerformanceMetricsUseCases(
+        doWorkoutPerformanceMetricsRepository: DoWorkoutPerformanceMetricsRepository
+    ): DoWorkoutPerformanceMetricsUseCases {
+        return DoWorkoutPerformanceMetricsUseCases(
+            deleteDoWorkoutPerformanceMetricsUseCase = DeleteDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            updateDoWorkoutPerformanceMetricsUseCase = UpdateDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            getAllDoWorkoutPerformanceMetricsUseCase = GetAllDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            getDoWorkoutPerformanceMetricsUseCase = GetDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            saveAllDoWorkoutExerciseSetUseCase = SaveAllDoWorkoutExerciseSetUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            saveDoWorkoutExerciseSetUseCase = SaveDoWorkoutExerciseSetUseCase(
+                doWorkoutPerformanceMetricsRepository
+            ),
+            saveDoWorkoutPerformanceMetricsUseCase = SaveDoWorkoutPerformanceMetricsUseCase(
+                doWorkoutPerformanceMetricsRepository
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/ExerciseModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/ExerciseModule.kt
@@ -1,0 +1,107 @@
+package com.koleff.kare_android.common.di
+
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.data.datasource.ExerciseDataSource
+import com.koleff.kare_android.data.datasource.ExerciseLocalDataSourceV2
+import com.koleff.kare_android.data.datasource.ExerciseRemoteDataSource
+import com.koleff.kare_android.data.remote.ExerciseApi
+import com.koleff.kare_android.data.repository.ExerciseRepositoryImpl
+import com.koleff.kare_android.data.room.dao.ExerciseDao
+import com.koleff.kare_android.data.room.dao.ExerciseDetailsDao
+import com.koleff.kare_android.data.room.dao.ExerciseSetDao
+import com.koleff.kare_android.domain.repository.ExerciseRepository
+import com.koleff.kare_android.domain.usecases.AddNewExerciseSetUseCase
+import com.koleff.kare_android.domain.usecases.DeleteExerciseSetUseCase
+import com.koleff.kare_android.domain.usecases.ExerciseUseCases
+import com.koleff.kare_android.domain.usecases.GetCatalogExerciseUseCase
+import com.koleff.kare_android.domain.usecases.GetCatalogExercisesUseCase
+import com.koleff.kare_android.domain.usecases.GetExerciseDetailsUseCase
+import com.koleff.kare_android.domain.usecases.GetExerciseUseCase
+import com.koleff.kare_android.domain.usecases.OnFilterExercisesUseCase
+import com.koleff.kare_android.domain.usecases.OnSearchExerciseUseCase
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ExerciseModule {
+
+    /**
+     * API
+     */
+
+    @Provides
+    @Singleton
+    fun provideExerciseApi(okHttpClient: OkHttpClient, moshi: Moshi): ExerciseApi {
+        return Retrofit.Builder()
+            .baseUrl(Constants.BASE_URL_FULL)
+            .client(okHttpClient)
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+//            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ExerciseApi::class.java)
+    }
+
+    /**
+     * Data source
+     */
+
+    @Provides
+    @Singleton
+    fun provideExerciseDataSource(
+        exerciseApi: ExerciseApi,
+        exerciseDao: ExerciseDao,
+        exerciseDetailsDao: ExerciseDetailsDao,
+        exerciseSetDao: ExerciseSetDao,
+        networkManager: NetworkManager
+    ): ExerciseDataSource {
+        return if (Constants.useLocalDataSource) ExerciseLocalDataSourceV2(
+            exerciseDao = exerciseDao,
+            exerciseDetailsDao = exerciseDetailsDao,
+            exerciseSetDao = exerciseSetDao
+        )
+        else ExerciseRemoteDataSource(
+            exerciseApi = exerciseApi,
+            networkManager = networkManager
+        )
+    }
+
+    /**
+     * Repository
+     */
+
+    @Provides
+    @Singleton
+    fun provideExerciseRepository(exerciseDataSource: ExerciseDataSource): ExerciseRepository {
+        return ExerciseRepositoryImpl(exerciseDataSource)
+    }
+
+    /**
+     * Use cases
+     */
+
+    @Provides
+    @Singleton
+    fun provideExerciseUseCases(exerciseRepository: ExerciseRepository): ExerciseUseCases {
+        return ExerciseUseCases(
+            onSearchExerciseUseCase = OnSearchExerciseUseCase(),
+            onFilterExercisesUseCase = OnFilterExercisesUseCase(),
+            getExerciseDetailsUseCase = GetExerciseDetailsUseCase(exerciseRepository),
+            getCatalogExercisesUseCase = GetCatalogExercisesUseCase(exerciseRepository),
+            getCatalogExerciseUseCase = GetCatalogExerciseUseCase(exerciseRepository),
+            deleteExerciseSetUseCase = DeleteExerciseSetUseCase(exerciseRepository),
+            addNewExerciseSetUseCase = AddNewExerciseSetUseCase(exerciseRepository),
+            getExerciseUseCase = GetExerciseUseCase(exerciseRepository)
+        )
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/ExerciseModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/ExerciseModule.kt
@@ -2,7 +2,7 @@ package com.koleff.kare_android.common.di
 
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.koleff.kare_android.common.Constants
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
 import com.koleff.kare_android.data.datasource.ExerciseDataSource
 import com.koleff.kare_android.data.datasource.ExerciseLocalDataSourceV2
 import com.koleff.kare_android.data.datasource.ExerciseRemoteDataSource
@@ -63,7 +63,7 @@ object ExerciseModule {
         exerciseDao: ExerciseDao,
         exerciseDetailsDao: ExerciseDetailsDao,
         exerciseSetDao: ExerciseSetDao,
-        networkManager: NetworkManager
+        apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper
     ): ExerciseDataSource {
         return if (Constants.useLocalDataSource) ExerciseLocalDataSourceV2(
             exerciseDao = exerciseDao,
@@ -72,7 +72,7 @@ object ExerciseModule {
         )
         else ExerciseRemoteDataSource(
             exerciseApi = exerciseApi,
-            networkManager = networkManager
+            apiAuthorizationCallWrapper = apiAuthorizationCallWrapper
         )
     }
 

--- a/app/src/main/java/com/koleff/kare_android/common/di/NavigationModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/NavigationModule.kt
@@ -5,13 +5,14 @@ import com.koleff.kare_android.common.navigation.NavigationControllerImpl
 import com.koleff.kare_android.common.navigation.NavigationNotifier
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class NavigationModule {
+abstract class NavigationBindModule {
 
     @Binds
     @Singleton
@@ -20,4 +21,14 @@ abstract class NavigationModule {
     @Binds
     @Singleton
     abstract fun bindNavigationNotifier(impl: NavigationControllerImpl): NavigationNotifier
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NavigationModule{
+    @Provides
+    @Singleton
+    fun provideNavigationControllerImpl(): NavigationControllerImpl {
+        return NavigationControllerImpl()
+    }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
@@ -1,0 +1,20 @@
+package com.koleff.kare_android.common.di
+
+import com.koleff.kare_android.common.broadcast.RegenerateTokenBroadcastReceiver
+import com.koleff.kare_android.common.network.RegenerateTokenNotifier
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class NetworkModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindRegenerateTokenNotifier(
+        impl: RegenerateTokenBroadcastReceiver
+    ): RegenerateTokenNotifier
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
@@ -1,6 +1,5 @@
 package com.koleff.kare_android.common.di
 
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.koleff.kare_android.common.broadcast.RegenerateTokenHandler
 import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
 import com.koleff.kare_android.common.network.NetworkManager
@@ -26,16 +25,18 @@ abstract class NetworkBindModule {
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NetworkModule{
+object NetworkModule {
+
+    //TODO: removed due to circular dependency...
     @Provides
     @Singleton
     fun provideNetworkManager(
-        broadcastManager: LocalBroadcastManager,
-        regenerateTokenNotifier: RegenerateTokenNotifier
+//        broadcastManager: LocalBroadcastManager,
+//        regenerateTokenNotifier: RegenerateTokenNotifier
     ): NetworkManager {
         return NetworkManager(
-            broadcastManager = broadcastManager,
-            regenerateTokenNotifier = regenerateTokenNotifier
+//            broadcastManager = broadcastManager,
+//            regenerateTokenNotifier = regenerateTokenNotifier
         )
     }
 

--- a/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
@@ -1,20 +1,53 @@
 package com.koleff.kare_android.common.di
 
-import com.koleff.kare_android.common.broadcast.RegenerateTokenBroadcastReceiver
-import com.koleff.kare_android.common.network.RegenerateTokenNotifier
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.koleff.kare_android.common.broadcast.RegenerateTokenHandler
+import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
+import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class NetworkModule {
+abstract class NetworkBindModule {
 
     @Binds
     @Singleton
     abstract fun bindRegenerateTokenNotifier(
-        impl: RegenerateTokenBroadcastReceiver
+        impl: RegenerateTokenHandler
     ): RegenerateTokenNotifier
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule{
+    @Provides
+    @Singleton
+    fun provideNetworkManager(
+        broadcastManager: LocalBroadcastManager,
+        regenerateTokenNotifier: RegenerateTokenNotifier
+    ): NetworkManager {
+        return NetworkManager(
+            broadcastManager = broadcastManager,
+            regenerateTokenNotifier = regenerateTokenNotifier
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideRegenerateTokenHandler(
+        authenticationUseCases: AuthenticationUseCases,
+        preferences: Preferences
+    ): RegenerateTokenHandler {
+        return RegenerateTokenHandler(
+            authenticationUseCases = authenticationUseCases,
+            preferences = preferences
+        )
+    }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
@@ -4,6 +4,8 @@ import com.koleff.kare_android.common.broadcast.RegenerateTokenHandler
 import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
 import com.koleff.kare_android.common.network.NetworkManager
 import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.common.preferences.TokenDataStore
+import com.koleff.kare_android.common.preferences.TokenDataStoreImpl
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import dagger.Binds
 import dagger.Module
@@ -27,7 +29,6 @@ abstract class NetworkBindModule {
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
-    //TODO: removed due to circular dependency...
     @Provides
     @Singleton
     fun provideNetworkManager(
@@ -44,10 +45,20 @@ object NetworkModule {
     @Singleton
     fun provideRegenerateTokenHandler(
         authenticationUseCases: AuthenticationUseCases,
-        preferences: Preferences
+        tokenDataStore: TokenDataStore
     ): RegenerateTokenHandler {
         return RegenerateTokenHandler(
             authenticationUseCases = authenticationUseCases,
+            tokenDataStore = tokenDataStore
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideTokenDataStore(
+        preferences: Preferences
+    ): TokenDataStore {
+        return TokenDataStoreImpl(
             preferences = preferences
         )
     }

--- a/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
@@ -14,6 +14,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module
@@ -49,7 +50,7 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideRegenerateTokenHandler(
-        authenticationUseCases: AuthenticationUseCases,
+        authenticationUseCases: Provider<AuthenticationUseCases>,
         tokenDataStore: TokenDataStore
     ): RegenerateTokenHandler {
         return RegenerateTokenHandler(

--- a/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/NetworkModule.kt
@@ -1,8 +1,10 @@
 package com.koleff.kare_android.common.di
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.koleff.kare_android.common.broadcast.RegenerateTokenHandler
 import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
+import com.koleff.kare_android.common.network.ApiCallWrapper
 import com.koleff.kare_android.common.preferences.Preferences
 import com.koleff.kare_android.common.preferences.TokenDataStore
 import com.koleff.kare_android.common.preferences.TokenDataStoreImpl
@@ -29,15 +31,18 @@ abstract class NetworkBindModule {
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
+    /**
+     * Requiring authorization
+     */
     @Provides
     @Singleton
-    fun provideNetworkManager(
-//        broadcastManager: LocalBroadcastManager,
-//        regenerateTokenNotifier: RegenerateTokenNotifier
-    ): NetworkManager {
-        return NetworkManager(
-//            broadcastManager = broadcastManager,
-//            regenerateTokenNotifier = regenerateTokenNotifier
+    fun provideApiAuthorizationCallWrapper(
+        broadcastManager: LocalBroadcastManager,
+        regenerateTokenNotifier: RegenerateTokenNotifier
+    ): ApiAuthorizationCallWrapper {
+        return ApiAuthorizationCallWrapper(
+            broadcastManager = broadcastManager,
+            regenerateTokenNotifier = regenerateTokenNotifier
         )
     }
 
@@ -61,5 +66,15 @@ object NetworkModule {
         return TokenDataStoreImpl(
             preferences = preferences
         )
+    }
+
+    /**
+     * Not requiring authorization
+     */
+
+    @Provides
+    @Singleton
+    fun provideApiCallWrapper(): ApiCallWrapper {
+        return ApiCallWrapper()
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/di/UserModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/UserModule.kt
@@ -1,0 +1,79 @@
+package com.koleff.kare_android.common.di
+
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.data.datasource.DashboardDataSource
+import com.koleff.kare_android.data.datasource.UserDataSource
+import com.koleff.kare_android.data.datasource.UserLocalDataSource
+import com.koleff.kare_android.data.datasource.UserRemoteDataSource
+import com.koleff.kare_android.data.remote.UserApi
+import com.koleff.kare_android.data.repository.DashboardRepositoryImpl
+import com.koleff.kare_android.data.repository.UserRepositoryImpl
+import com.koleff.kare_android.data.room.dao.UserDao
+import com.koleff.kare_android.domain.repository.DashboardRepository
+import com.koleff.kare_android.domain.repository.UserRepository
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UserModule {
+
+    /**
+     * API
+     */
+
+    @Provides
+    @Singleton
+    fun provideUserApi(okHttpClient: OkHttpClient, moshi: Moshi): UserApi {
+        return Retrofit.Builder()
+            .baseUrl(Constants.BASE_URL_FULL)
+            .client(okHttpClient)
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+//            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(UserApi::class.java)
+    }
+
+    /**
+     * Data sources
+     */
+
+    @Provides
+    @Singleton
+    fun provideUserDataSource(
+        userDao: UserDao,
+        userApi: UserApi,
+        networkManager: NetworkManager,
+        @IoDispatcher dispatcher: CoroutineDispatcher
+    ): UserDataSource {
+        return if (Constants.useLocalDataSource) UserLocalDataSource(
+            userDao = userDao
+        )
+        else UserRemoteDataSource(
+            userApi = userApi,
+            networkManager = networkManager,
+            dispatcher = dispatcher
+        )
+    }
+
+    /**
+     * Repositories
+     */
+
+    @Provides
+    @Singleton
+    fun provideUserRepository(userDataSource: UserDataSource): UserRepository {
+        return UserRepositoryImpl(userDataSource)
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/UserModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/UserModule.kt
@@ -2,7 +2,7 @@ package com.koleff.kare_android.common.di
 
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.koleff.kare_android.common.Constants
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
 import com.koleff.kare_android.data.datasource.DashboardDataSource
 import com.koleff.kare_android.data.datasource.UserDataSource
 import com.koleff.kare_android.data.datasource.UserLocalDataSource
@@ -54,7 +54,7 @@ object UserModule {
     fun provideUserDataSource(
         userDao: UserDao,
         userApi: UserApi,
-        networkManager: NetworkManager,
+        apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper,
         @IoDispatcher dispatcher: CoroutineDispatcher
     ): UserDataSource {
         return if (Constants.useLocalDataSource) UserLocalDataSource(
@@ -62,7 +62,7 @@ object UserModule {
         )
         else UserRemoteDataSource(
             userApi = userApi,
-            networkManager = networkManager,
+            apiAuthorizationCallWrapper = apiAuthorizationCallWrapper,
             dispatcher = dispatcher
         )
     }

--- a/app/src/main/java/com/koleff/kare_android/common/di/WorkoutModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/WorkoutModule.kt
@@ -1,0 +1,151 @@
+package com.koleff.kare_android.common.di
+
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.data.datasource.WorkoutDataSource
+import com.koleff.kare_android.data.datasource.WorkoutLocalDataSourceV2
+import com.koleff.kare_android.data.datasource.WorkoutRemoteDataSource
+import com.koleff.kare_android.data.remote.WorkoutApi
+import com.koleff.kare_android.data.repository.WorkoutRepositoryImpl
+import com.koleff.kare_android.data.room.dao.ExerciseDao
+import com.koleff.kare_android.data.room.dao.ExerciseSetDao
+import com.koleff.kare_android.data.room.dao.WorkoutConfigurationDao
+import com.koleff.kare_android.data.room.dao.WorkoutDao
+import com.koleff.kare_android.data.room.dao.WorkoutDetailsDao
+import com.koleff.kare_android.domain.repository.WorkoutRepository
+import com.koleff.kare_android.domain.usecases.AddExerciseUseCase
+import com.koleff.kare_android.domain.usecases.AddMultipleExercisesUseCase
+import com.koleff.kare_android.domain.usecases.CreateCustomWorkoutDetailsUseCase
+import com.koleff.kare_android.domain.usecases.CreateCustomWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.CreateNewWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.CreateWorkoutConfigurationUseCase
+import com.koleff.kare_android.domain.usecases.DeleteExerciseUseCase
+import com.koleff.kare_android.domain.usecases.DeleteMultipleExercisesUseCase
+import com.koleff.kare_android.domain.usecases.DeleteWorkoutConfigurationUseCase
+import com.koleff.kare_android.domain.usecases.DeleteWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.FavoriteWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.FindDuplicateExercisesUseCase
+import com.koleff.kare_android.domain.usecases.GetAllWorkoutDetailsUseCase
+import com.koleff.kare_android.domain.usecases.GetAllWorkoutsUseCase
+import com.koleff.kare_android.domain.usecases.GetFavoriteWorkoutsUseCase
+import com.koleff.kare_android.domain.usecases.GetWorkoutConfigurationUseCase
+import com.koleff.kare_android.domain.usecases.GetWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.GetWorkoutsDetailsUseCase
+import com.koleff.kare_android.domain.usecases.OnSearchWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.SubmitExerciseUseCase
+import com.koleff.kare_android.domain.usecases.SubmitMultipleExercisesUseCase
+import com.koleff.kare_android.domain.usecases.UnfavoriteWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.UpdateWorkoutConfigurationUseCase
+import com.koleff.kare_android.domain.usecases.UpdateWorkoutDetailsUseCase
+import com.koleff.kare_android.domain.usecases.UpdateWorkoutUseCase
+import com.koleff.kare_android.domain.usecases.WorkoutUseCases
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object WorkoutModule {
+
+    /**
+     * API
+     */
+
+    @Provides
+    @Singleton
+    fun provideWorkoutApi(okHttpClient: OkHttpClient, moshi: Moshi): WorkoutApi {
+        return Retrofit.Builder()
+            .baseUrl(Constants.BASE_URL_FULL)
+            .client(okHttpClient)
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+//            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(WorkoutApi::class.java)
+    }
+
+    /**
+     * Data sources
+     */
+
+    @Provides
+    @Singleton
+    fun provideWorkoutDataSource(
+        workoutApi: WorkoutApi,
+        workoutDao: WorkoutDao,
+        exerciseDao: ExerciseDao,
+        workoutDetailsDao: WorkoutDetailsDao,
+        exerciseSetDao: ExerciseSetDao,
+        workoutConfigurationDao: WorkoutConfigurationDao,
+        networkManager: NetworkManager,
+        @IoDispatcher dispatcher: CoroutineDispatcher
+    ): WorkoutDataSource {
+        return if (Constants.useLocalDataSource) WorkoutLocalDataSourceV2(
+            workoutDao = workoutDao,
+            exerciseDao = exerciseDao,
+            workoutDetailsDao = workoutDetailsDao,
+            exerciseSetDao = exerciseSetDao,
+            workoutConfigurationDao = workoutConfigurationDao
+
+        )
+        else WorkoutRemoteDataSource(
+            workoutApi = workoutApi,
+            networkManager = networkManager,
+            dispatcher = dispatcher
+        )
+    }
+
+    /**
+     * Repository
+     */
+
+    @Provides
+    @Singleton
+    fun provideWorkoutRepository(workoutDataSource: WorkoutDataSource): WorkoutRepository {
+        return WorkoutRepositoryImpl(workoutDataSource)
+    }
+
+    /**
+     * Use Cases
+     */
+
+    @Provides
+    @Singleton
+    fun provideWorkoutUseCases(workoutRepository: WorkoutRepository): WorkoutUseCases {
+        return WorkoutUseCases(
+            getWorkoutDetailsUseCase = GetWorkoutsDetailsUseCase(workoutRepository),
+            getAllWorkoutsUseCase = GetAllWorkoutsUseCase(workoutRepository),
+            getAllWorkoutDetailsUseCase = GetAllWorkoutDetailsUseCase(workoutRepository),
+            getWorkoutUseCase = GetWorkoutUseCase(workoutRepository),
+            updateWorkoutUseCase = UpdateWorkoutUseCase(workoutRepository),
+            updateWorkoutDetailsUseCase = UpdateWorkoutDetailsUseCase(workoutRepository),
+            onSearchWorkoutUseCase = OnSearchWorkoutUseCase(),
+            deleteExerciseUseCase = DeleteExerciseUseCase(workoutRepository),
+            deleteMultipleExercisesUseCase = DeleteMultipleExercisesUseCase(workoutRepository),
+            addExerciseUseCase = AddExerciseUseCase(workoutRepository),
+            addMultipleExercisesUseCase = AddMultipleExercisesUseCase(workoutRepository),
+            submitExerciseUseCase = SubmitExerciseUseCase(workoutRepository),
+            submitMultipleExercisesUseCase = SubmitMultipleExercisesUseCase(workoutRepository),
+            findDuplicateExercisesUseCase = FindDuplicateExercisesUseCase(workoutRepository),
+            deleteWorkoutUseCase = DeleteWorkoutUseCase(workoutRepository),
+            favoriteWorkoutUseCase = FavoriteWorkoutUseCase(workoutRepository),
+            unfavoriteWorkoutUseCase = UnfavoriteWorkoutUseCase(workoutRepository),
+            getFavoriteWorkoutsUseCase = GetFavoriteWorkoutsUseCase(workoutRepository),
+            createNewWorkoutUseCase = CreateNewWorkoutUseCase(workoutRepository),
+            createCustomWorkoutUseCase = CreateCustomWorkoutUseCase(workoutRepository),
+            createCustomWorkoutDetailsUseCase = CreateCustomWorkoutDetailsUseCase(workoutRepository),
+            getWorkoutConfigurationUseCase = GetWorkoutConfigurationUseCase(workoutRepository),
+            createWorkoutConfigurationUseCase = CreateWorkoutConfigurationUseCase(workoutRepository),
+            updateWorkoutConfigurationUseCase = UpdateWorkoutConfigurationUseCase(workoutRepository),
+            deleteWorkoutConfigurationUseCase = DeleteWorkoutConfigurationUseCase(workoutRepository)
+        )
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/di/WorkoutModule.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/di/WorkoutModule.kt
@@ -2,7 +2,7 @@ package com.koleff.kare_android.common.di
 
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.koleff.kare_android.common.Constants
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
 import com.koleff.kare_android.data.datasource.WorkoutDataSource
 import com.koleff.kare_android.data.datasource.WorkoutLocalDataSourceV2
 import com.koleff.kare_android.data.datasource.WorkoutRemoteDataSource
@@ -85,7 +85,7 @@ object WorkoutModule {
         workoutDetailsDao: WorkoutDetailsDao,
         exerciseSetDao: ExerciseSetDao,
         workoutConfigurationDao: WorkoutConfigurationDao,
-        networkManager: NetworkManager,
+        apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper,
         @IoDispatcher dispatcher: CoroutineDispatcher
     ): WorkoutDataSource {
         return if (Constants.useLocalDataSource) WorkoutLocalDataSourceV2(
@@ -98,7 +98,7 @@ object WorkoutModule {
         )
         else WorkoutRemoteDataSource(
             workoutApi = workoutApi,
-            networkManager = networkManager,
+            apiAuthorizationCallWrapper = apiAuthorizationCallWrapper,
             dispatcher = dispatcher
         )
     }

--- a/app/src/main/java/com/koleff/kare_android/common/navigation/NavigationControllerImpl.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/navigation/NavigationControllerImpl.kt
@@ -4,14 +4,12 @@ import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class NavigationControllerImpl @Inject constructor() : NavigationController, NavigationNotifier {
+class NavigationControllerImpl: NavigationController, NavigationNotifier {
 
     private val _navigationEvents = MutableSharedFlow<NavigationEvent>(replay = 1)
-
     override val navigationEvents: Flow<NavigationEvent> = _navigationEvents.asSharedFlow()
 
     override suspend fun navigateTo(destination: Destination) {

--- a/app/src/main/java/com/koleff/kare_android/common/network/ApiCallWrapper.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/network/ApiCallWrapper.kt
@@ -1,0 +1,81 @@
+package com.koleff.kare_android.common.network
+
+import android.util.Log
+import com.koleff.kare_android.data.model.response.base_response.KareError
+import com.koleff.kare_android.domain.wrapper.ResultWrapper
+import com.koleff.kare_android.domain.wrapper.ServerResponseData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import retrofit2.HttpException
+
+/**
+ * Used for API requests that don't require authorization tokens
+ * - Login
+ * - Register
+ */
+class ApiCallWrapper {
+    companion object {
+        private const val MAX_RETRY_COUNT = 1
+    }
+
+    suspend fun <T> executeApiCall(
+        dispatcher: CoroutineDispatcher,
+        apiCall: suspend () -> T,
+        unsuccessfulRetriesCount: Int = 0
+    ): Flow<ResultWrapper<T>> where T : ServerResponseData = flow {
+        try {
+            emit(ResultWrapper.Loading())
+
+            Log.d("ApiCallWrapper", "Network request sent.")
+            val apiResult = apiCall.invoke()
+
+            if (apiResult.isSuccessful) {
+                emit(ResultWrapper.Success(apiResult))
+            } else {
+                emit(
+                    ResultWrapper.ApiError(
+                        apiResult.error,
+                        apiResult
+                    )
+                )
+            }
+        } catch (throwable: Throwable) {
+            throwable.printStackTrace()
+
+            val error = when (throwable) {
+                is HttpException -> KareError.NETWORK
+                else -> KareError.GENERIC
+            }
+            emitAll(doRetryCall(dispatcher, apiCall, error, unsuccessfulRetriesCount))
+        }
+    }.flowOn(dispatcher)
+
+    private suspend fun <T> doRetryCall(
+        dispatcher: CoroutineDispatcher,
+        apiCall: suspend () -> T,
+        error: KareError,
+        unsuccessfulRetriesCount: Int = 0
+    ): Flow<ResultWrapper<T>> where T : ServerResponseData {
+        Log.d("ApiCallWrapper", "Network request failed. Retrying...")
+
+        return if (unsuccessfulRetriesCount < MAX_RETRY_COUNT) {
+            executeApiCall(dispatcher, apiCall, unsuccessfulRetriesCount + 1)
+        } else {
+            Log.d(
+                "ApiCallWrapper",
+                "Network request failed. Error: $error."
+            )
+
+            flowOf(
+                ResultWrapper.ApiError(
+                    error,
+                    null
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/network/BearerTokenInterceptor.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/network/BearerTokenInterceptor.kt
@@ -1,0 +1,49 @@
+package com.koleff.kare_android.common.network
+
+import android.content.Intent
+import android.util.Log
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
+import com.koleff.kare_android.common.preferences.Preferences
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BearerTokenInterceptor @Inject constructor(
+    private val preferences: Preferences
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val original = chain.request()
+
+        val newUrl = original.url.newBuilder()
+            .scheme(Constants.SCHEME)
+            .host(Constants.BASE_URL)
+//                    .port(Constants.PORT) //if port is needed
+//                    .addQueryParameter("access_key", Constants.API_KEY) //if API key is needed
+            .build()
+
+        val requestBuilder = original.newBuilder()
+            .method(original.method, original.body)
+            .url(newUrl)
+
+        val unauthorizedRequestPaths = listOf("/login", "/register")
+        val requestPath = original.url.encodedPath
+
+        //Add token authorization for all requests except auth ones
+        if (!requestPath.endsWith(unauthorizedRequestPaths[0]) &&
+            !requestPath.endsWith(unauthorizedRequestPaths[1])) {
+            val tokens = preferences.getTokens()
+            val accessToken = tokens?.accessToken ?: ""
+
+            requestBuilder.addHeader("Authorization", "Bearer $accessToken}")
+        }
+
+        val request = requestBuilder.build()
+        val response = chain.proceed(request)
+        return response
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/network/NetworkManager.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/network/NetworkManager.kt
@@ -1,9 +1,11 @@
 package com.koleff.kare_android.common.network
 
 import android.util.Log
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.koleff.kare_android.data.model.response.base_response.KareError
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.domain.wrapper.ServerResponseData
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
@@ -11,9 +13,16 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import retrofit2.HttpException
+import javax.inject.Inject
 
-object Network {
-    private const val MAX_RETRY_COUNT = 1
+@AndroidEntryPoint
+class NetworkManager {
+
+    @Inject
+    lateinit var broadcastManager: LocalBroadcastManager
+    companion object{
+        private const val MAX_RETRY_COUNT = 1
+    }
 
     suspend fun <T> executeApiCall(
         dispatcher: CoroutineDispatcher,
@@ -31,9 +40,10 @@ object Network {
             } else {
                 when(apiResult.error){
 
-                    //Regenerate token and try again
+                    //Regenerate token
+                    //TODO: on success -> doRetryCall...
                     KareError.TOKEN_EXPIRED -> {
-                        regenerateToken() //TODO: broadcast?
+                        regenerateToken() //TODO: await response?
                         return@flow
                     }
 
@@ -67,9 +77,9 @@ object Network {
 
     private fun logout() {
         Log.d("Network", "Invalid token. Logging out.")
+
     }
 
-    //TODO: create regenerate token listener/service that on call/trigger regenerates...
     private fun regenerateToken() {
         Log.d("Network", "Token regenerating...")
     }

--- a/app/src/main/java/com/koleff/kare_android/common/network/NetworkManager.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/network/NetworkManager.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.util.Log
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
 import com.koleff.kare_android.data.model.response.base_response.KareError
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.domain.wrapper.ServerResponseData
@@ -17,15 +18,19 @@ import retrofit2.HttpException
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@Singleton
 class NetworkManager @Inject constructor(
-    private val broadcastManager: LocalBroadcastManager,
-    private val regenerateTokenNotifier: RegenerateTokenNotifier
+//    private val broadcastManager: LocalBroadcastManager,
+//    private val regenerateTokenNotifier: RegenerateTokenNotifier
 ) {
+    @Inject
+    lateinit var broadcastManager: LocalBroadcastManager
+
+    @Inject
+    lateinit var regenerateTokenNotifier: RegenerateTokenNotifier
+
     companion object {
         private const val MAX_RETRY_COUNT = 1
     }
-
 
     suspend fun <T> executeApiCall(
         dispatcher: CoroutineDispatcher,

--- a/app/src/main/java/com/koleff/kare_android/common/network/RegenerateTokenInterceptor.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/network/RegenerateTokenInterceptor.kt
@@ -1,0 +1,83 @@
+package com.koleff.kare_android.common.network
+
+import android.content.Intent
+import android.util.Log
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
+import com.koleff.kare_android.common.preferences.Preferences
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RegenerateTokenInterceptor @Inject constructor(
+    private val preferences: Preferences,
+    private val broadcastManager: LocalBroadcastManager,
+    private val regenerateTokenNotifier: RegenerateTokenNotifier
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val tokens = preferences.getTokens()
+        val accessToken = tokens?.accessToken ?: ""
+
+        val newRequest = originalRequest.newBuilder()
+            .addHeader("Authorization", "Bearer $accessToken")
+            .build()
+
+        val response = chain.proceed(newRequest)
+
+        //Unauthorized
+        return if (response.code == 401) {
+            response.close()
+
+            lateinit var retryResponse: Response
+
+            //On success
+            regenerateToken {
+                val newToken = preferences.getTokens() ?: return@regenerateToken
+
+                //Re-build request
+                val retriedRequest = originalRequest.newBuilder()
+                    .removeHeader("Authorization")
+                    .addHeader("Authorization", "Bearer ${newToken.accessToken}")
+                    .build()
+                retryResponse = chain.proceed(retriedRequest)
+            }
+
+            retryResponse
+        } else {
+            response
+        }
+    }
+
+    private fun logout() {
+        Log.d("ApiAuthorizationCallWrapper", "Invalid token. Logging out.")
+
+        val intent = Intent(Constants.ACTION_LOGOUT)
+        broadcastManager.sendBroadcast(intent)
+    }
+
+    private fun regenerateToken(onSuccess: () -> Unit) = runBlocking {
+        Log.d("ApiAuthorizationCallWrapper", "Token regenerating...")
+
+        val intent = Intent(Constants.ACTION_REGENERATE_TOKEN)
+        broadcastManager.sendBroadcast(intent)
+
+        regenerateTokenNotifier.regenerateTokenState.collect { result ->
+            Log.d("ApiAuthorizationCallWrapper", "Regenerate token state received. State: $result")
+
+            if (result.isSuccessful) {
+
+                //Retry API call
+                onSuccess()
+            } else if (result.isError) {
+
+                //Logout
+                logout()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/common/network/RegenerateTokenNotifier.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/network/RegenerateTokenNotifier.kt
@@ -1,0 +1,8 @@
+package com.koleff.kare_android.common.network
+
+import com.koleff.kare_android.ui.state.TokenState
+import kotlinx.coroutines.flow.Flow
+
+interface RegenerateTokenNotifier {
+    val regenerateTokenState: Flow<TokenState>
+}

--- a/app/src/main/java/com/koleff/kare_android/common/preferences/CredentialsDataStore.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/preferences/CredentialsDataStore.kt
@@ -1,0 +1,12 @@
+package com.koleff.kare_android.common.preferences
+
+import com.koleff.kare_android.common.auth.Credentials
+
+interface CredentialsDataStore {
+
+    fun getCredentials(): Credentials?
+
+    fun saveCredentials(credentials: Credentials)
+
+    fun deleteCredentials()
+}

--- a/app/src/main/java/com/koleff/kare_android/common/preferences/CredentialsDataStoreImpl.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/preferences/CredentialsDataStoreImpl.kt
@@ -1,8 +1,9 @@
-package com.koleff.kare_android.common.auth
+package com.koleff.kare_android.common.preferences
 
-import com.koleff.kare_android.common.preferences.Preferences
+import com.koleff.kare_android.common.auth.Credentials
+import javax.inject.Inject
 
-class CredentialsDataStoreImpl(
+class CredentialsDataStoreImpl @Inject constructor(
     private val preferences: Preferences
 ): CredentialsDataStore {
     override fun getCredentials(): Credentials? {
@@ -11,5 +12,9 @@ class CredentialsDataStoreImpl(
 
     override fun saveCredentials(credentials: Credentials) {
         preferences.saveCredentials(credentials)
+    }
+
+    override fun deleteCredentials() {
+        preferences.deleteCredentials()
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/preferences/DefaultPreferences.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/preferences/DefaultPreferences.kt
@@ -10,7 +10,6 @@ import com.koleff.kare_android.data.model.dto.MuscleGroup
 import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
 import com.koleff.kare_android.data.model.dto.WorkoutDto
-import java.lang.NullPointerException
 import java.lang.reflect.Type
 
 
@@ -186,5 +185,16 @@ class DefaultPreferences(
                 else -> throw ex
             }
         }
+    }
+
+    override fun deleteTokens() {
+        sharedPref.edit()
+            .putString(Preferences.TOKENS, "")
+            .apply()
+    }
+
+    override fun updateTokens(tokens: Tokens) {
+        deleteTokens()
+        saveTokens(tokens)
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/common/preferences/Preferences.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/preferences/Preferences.kt
@@ -21,6 +21,8 @@ interface Preferences {
     fun deleteCredentials()
     fun saveTokens(tokens: Tokens)
     fun getTokens(): Tokens?
+    fun deleteTokens()
+    fun updateTokens(tokens: Tokens)
 
     companion object {
         const val DASHBOARD_MUSCLE_GROUP_LIST = "dashboard_muscle_group_list"

--- a/app/src/main/java/com/koleff/kare_android/common/preferences/TokenDataStore.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/preferences/TokenDataStore.kt
@@ -1,0 +1,12 @@
+package com.koleff.kare_android.common.preferences
+
+import com.koleff.kare_android.data.model.dto.Tokens
+
+interface TokenDataStore {
+
+    fun getTokens(): Tokens?
+
+    fun updateTokens(tokens: Tokens)
+
+    fun deleteTokens()
+}

--- a/app/src/main/java/com/koleff/kare_android/common/preferences/TokenDataStoreImpl.kt
+++ b/app/src/main/java/com/koleff/kare_android/common/preferences/TokenDataStoreImpl.kt
@@ -1,0 +1,20 @@
+package com.koleff.kare_android.common.preferences
+
+import com.koleff.kare_android.data.model.dto.Tokens
+import javax.inject.Inject
+
+class TokenDataStoreImpl @Inject constructor(
+    private val preferences: Preferences
+): TokenDataStore {
+    override fun getTokens(): Tokens? {
+        return preferences.getTokens()
+    }
+
+    override fun updateTokens(tokens: Tokens) {
+        preferences.updateTokens(tokens)
+    }
+
+    override fun deleteTokens() {
+        preferences.deleteTokens()
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationDataSource.kt
@@ -1,10 +1,12 @@
 package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.auth.Credentials
+import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
 import com.koleff.kare_android.domain.wrapper.LoginWrapper
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.domain.wrapper.ServerResponseData
+import com.koleff.kare_android.domain.wrapper.TokenWrapper
 import kotlinx.coroutines.flow.Flow
 
 interface AuthenticationDataSource {
@@ -14,4 +16,6 @@ interface AuthenticationDataSource {
     suspend fun register(user: UserDto): Flow<ResultWrapper<ServerResponseData>>
 
     suspend fun logout(user: UserDto): Flow<ResultWrapper<ServerResponseData>>
+
+    suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>>
 }

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationLocalDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationLocalDataSource.kt
@@ -1,21 +1,22 @@
 package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.common.MockupDataGeneratorV2
 import com.koleff.kare_android.common.auth.Credentials
 import com.koleff.kare_android.common.auth.CredentialsAuthenticator
+import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
 import com.koleff.kare_android.data.model.response.LoginResponse
+import com.koleff.kare_android.data.model.response.TokenResponse
 import com.koleff.kare_android.data.model.response.base_response.BaseResponse
 import com.koleff.kare_android.data.model.response.base_response.KareError
 import com.koleff.kare_android.data.room.dao.UserDao
 import com.koleff.kare_android.domain.wrapper.LoginWrapper
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.domain.wrapper.ServerResponseData
-import com.koleff.kare_android.ui.state.BaseState
+import com.koleff.kare_android.domain.wrapper.TokenWrapper
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 
@@ -88,6 +89,20 @@ class AuthenticationLocalDataSource(
 
             val result = ServerResponseData(
                 BaseResponse()
+            )
+
+            emit(ResultWrapper.Success(result))
+        }
+
+    override suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>> =
+        flow {
+            emit(ResultWrapper.Loading())
+            delay(Constants.fakeDelay)
+
+            val result = TokenWrapper(
+                TokenResponse(
+                    tokens = MockupDataGeneratorV2.generateTokens()
+                )
             )
 
             emit(ResultWrapper.Success(result))

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationRemoteDataSource.kt
@@ -2,7 +2,8 @@ package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.auth.Credentials
 import com.koleff.kare_android.common.di.IoDispatcher
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
+import com.koleff.kare_android.common.network.ApiCallWrapper
 import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
 import com.koleff.kare_android.data.model.request.RegenerateTokenRequest
@@ -21,7 +22,8 @@ typealias SignInRequest = RegistrationRequest
 
 class AuthenticationRemoteDataSource @Inject constructor(
     private val authenticationApi: AuthenticationApi,
-    private val networkManager: NetworkManager,
+    private val apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper,
+    private val apiCallWrapper: ApiCallWrapper,
     @IoDispatcher val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : AuthenticationDataSource {
     override suspend fun login(
@@ -29,7 +31,7 @@ class AuthenticationRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<LoginWrapper>> {
         val body = SignInRequest(credentials)
 
-        return networkManager.executeApiCall(dispatcher, {
+        return apiCallWrapper.executeApiCall(dispatcher, {
             LoginWrapper(
                 authenticationApi.login(body)
             )
@@ -39,7 +41,7 @@ class AuthenticationRemoteDataSource @Inject constructor(
     override suspend fun register(user: UserDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = RegistrationRequest(user)
 
-        return networkManager.executeApiCall(
+        return apiCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(authenticationApi.register(body)) }
         )
@@ -48,7 +50,7 @@ class AuthenticationRemoteDataSource @Inject constructor(
     override suspend fun logout(user: UserDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = RegistrationRequest(user)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(authenticationApi.logout(body)) }
         )
@@ -57,7 +59,7 @@ class AuthenticationRemoteDataSource @Inject constructor(
     override suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>> {
         val body = RegenerateTokenRequest(tokens)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { TokenWrapper(authenticationApi.regenerateToken(body)) }
         )

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationRemoteDataSource.kt
@@ -3,12 +3,15 @@ package com.koleff.kare_android.data.datasource
 import com.koleff.kare_android.common.auth.Credentials
 import com.koleff.kare_android.common.di.IoDispatcher
 import com.koleff.kare_android.common.network.Network
+import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
+import com.koleff.kare_android.data.model.request.RegenerateTokenRequest
 import com.koleff.kare_android.data.model.request.RegistrationRequest
 import com.koleff.kare_android.data.remote.AuthenticationApi
 import com.koleff.kare_android.domain.wrapper.LoginWrapper
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.domain.wrapper.ServerResponseData
+import com.koleff.kare_android.domain.wrapper.TokenWrapper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -48,6 +51,16 @@ class AuthenticationRemoteDataSource @Inject constructor(
         return Network.executeApiCall(dispatcher, {
             ServerResponseData(
                 authenticationApi.logout(body)
+            )
+        })
+    }
+
+    override suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>> {
+        val body = RegenerateTokenRequest(tokens)
+
+        return Network.executeApiCall(dispatcher, {
+            TokenWrapper(
+                authenticationApi.regenerateToken(body)
             )
         })
     }

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/AuthenticationRemoteDataSource.kt
@@ -2,7 +2,7 @@ package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.auth.Credentials
 import com.koleff.kare_android.common.di.IoDispatcher
-import com.koleff.kare_android.common.network.Network
+import com.koleff.kare_android.common.network.NetworkManager
 import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
 import com.koleff.kare_android.data.model.request.RegenerateTokenRequest
@@ -21,6 +21,7 @@ typealias SignInRequest = RegistrationRequest
 
 class AuthenticationRemoteDataSource @Inject constructor(
     private val authenticationApi: AuthenticationApi,
+    private val networkManager: NetworkManager,
     @IoDispatcher val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : AuthenticationDataSource {
     override suspend fun login(
@@ -28,7 +29,7 @@ class AuthenticationRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<LoginWrapper>> {
         val body = SignInRequest(credentials)
 
-        return Network.executeApiCall(dispatcher, {
+        return networkManager.executeApiCall(dispatcher, {
             LoginWrapper(
                 authenticationApi.login(body)
             )
@@ -38,30 +39,27 @@ class AuthenticationRemoteDataSource @Inject constructor(
     override suspend fun register(user: UserDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = RegistrationRequest(user)
 
-        return Network.executeApiCall(dispatcher, {
-            ServerResponseData(
-                authenticationApi.register(body)
-            )
-        })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(authenticationApi.register(body)) }
+        )
     }
 
     override suspend fun logout(user: UserDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = RegistrationRequest(user)
 
-        return Network.executeApiCall(dispatcher, {
-            ServerResponseData(
-                authenticationApi.logout(body)
-            )
-        })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(authenticationApi.logout(body)) }
+        )
     }
 
     override suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>> {
         val body = RegenerateTokenRequest(tokens)
 
-        return Network.executeApiCall(dispatcher, {
-            TokenWrapper(
-                authenticationApi.regenerateToken(body)
-            )
-        })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { TokenWrapper(authenticationApi.regenerateToken(body)) }
+        )
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/ExerciseRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/ExerciseRemoteDataSource.kt
@@ -1,19 +1,18 @@
 package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.Constants
-import com.koleff.kare_android.common.network.Network
 import com.koleff.kare_android.common.di.IoDispatcher
+import com.koleff.kare_android.common.network.NetworkManager
 import com.koleff.kare_android.data.model.dto.ExerciseSetDto
 import com.koleff.kare_android.data.model.request.AddNewExerciseSetRequest
 import com.koleff.kare_android.data.model.request.DeleteExerciseSetRequest
-import com.koleff.kare_android.domain.wrapper.ExerciseListWrapper
 import com.koleff.kare_android.data.model.request.FetchExerciseRequest
 import com.koleff.kare_android.data.model.request.FetchExercisesByMuscleGroupRequest
-import com.koleff.kare_android.data.model.request.FetchExercisesByWorkoutIdRequest
+import com.koleff.kare_android.data.remote.ExerciseApi
 import com.koleff.kare_android.domain.wrapper.ExerciseDetailsWrapper
+import com.koleff.kare_android.domain.wrapper.ExerciseListWrapper
 import com.koleff.kare_android.domain.wrapper.ExerciseWrapper
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
-import com.koleff.kare_android.data.remote.ExerciseApi
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +21,7 @@ import javax.inject.Inject
 
 class ExerciseRemoteDataSource @Inject constructor(
     private val exerciseApi: ExerciseApi,
+    private val networkManager: NetworkManager,
     @IoDispatcher val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ExerciseDataSource {
 
@@ -31,21 +31,28 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = FetchExerciseRequest(exerciseId, Constants.CATALOG_EXERCISE_ID)
 
-        return Network.executeApiCall(dispatcher, { ExerciseWrapper(exerciseApi.getExercise(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ExerciseWrapper(exerciseApi.getExercise(body)) }
+        )
     }
 
     override suspend fun getCatalogExercise(exerciseId: Int): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = FetchExerciseRequest(exerciseId, Constants.CATALOG_EXERCISE_ID)
 
-        return Network.executeApiCall(dispatcher, { ExerciseWrapper(exerciseApi.getCatalogExercise(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ExerciseWrapper(exerciseApi.getCatalogExercise(body)) }
+        )
     }
 
     override suspend fun getCatalogExercises(muscleGroupId: Int): Flow<ResultWrapper<ExerciseListWrapper>> {
         val body = FetchExercisesByMuscleGroupRequest(muscleGroupId)
 
-        return Network.executeApiCall(
+        return networkManager.executeApiCall(
             dispatcher,
-            { ExerciseListWrapper(exerciseApi.getCatalogExercises(body)) })
+            { ExerciseListWrapper(exerciseApi.getCatalogExercises(body)) }
+        )
     }
 
     override suspend fun getExerciseDetails(
@@ -54,7 +61,10 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseDetailsWrapper>> {
         val body = FetchExerciseRequest(exerciseId, workoutId)
 
-        return Network.executeApiCall(dispatcher, { ExerciseDetailsWrapper(exerciseApi.getExerciseDetails(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ExerciseDetailsWrapper(exerciseApi.getExerciseDetails(body)) }
+        )
     }
 
     override suspend fun addNewExerciseSet(
@@ -64,7 +74,10 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = AddNewExerciseSetRequest(exerciseId, workoutId, currentSets)
 
-        return Network.executeApiCall(dispatcher, { ExerciseWrapper(exerciseApi.addNewExerciseSet(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ExerciseWrapper(exerciseApi.addNewExerciseSet(body)) }
+        )
     }
 
     override suspend fun deleteExerciseSet(
@@ -75,6 +88,9 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = DeleteExerciseSetRequest(exerciseId, workoutId, setId, currentSets)
 
-        return Network.executeApiCall(dispatcher, { ExerciseWrapper(exerciseApi.deleteExerciseSet(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ExerciseWrapper(exerciseApi.deleteExerciseSet(body)) }
+        )
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/ExerciseRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/ExerciseRemoteDataSource.kt
@@ -2,7 +2,7 @@ package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.Constants
 import com.koleff.kare_android.common.di.IoDispatcher
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
 import com.koleff.kare_android.data.model.dto.ExerciseSetDto
 import com.koleff.kare_android.data.model.request.AddNewExerciseSetRequest
 import com.koleff.kare_android.data.model.request.DeleteExerciseSetRequest
@@ -21,7 +21,7 @@ import javax.inject.Inject
 
 class ExerciseRemoteDataSource @Inject constructor(
     private val exerciseApi: ExerciseApi,
-    private val networkManager: NetworkManager,
+    private val apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper,
     @IoDispatcher val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ExerciseDataSource {
 
@@ -31,7 +31,7 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = FetchExerciseRequest(exerciseId, Constants.CATALOG_EXERCISE_ID)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ExerciseWrapper(exerciseApi.getExercise(body)) }
         )
@@ -40,7 +40,7 @@ class ExerciseRemoteDataSource @Inject constructor(
     override suspend fun getCatalogExercise(exerciseId: Int): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = FetchExerciseRequest(exerciseId, Constants.CATALOG_EXERCISE_ID)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ExerciseWrapper(exerciseApi.getCatalogExercise(body)) }
         )
@@ -49,7 +49,7 @@ class ExerciseRemoteDataSource @Inject constructor(
     override suspend fun getCatalogExercises(muscleGroupId: Int): Flow<ResultWrapper<ExerciseListWrapper>> {
         val body = FetchExercisesByMuscleGroupRequest(muscleGroupId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ExerciseListWrapper(exerciseApi.getCatalogExercises(body)) }
         )
@@ -61,7 +61,7 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseDetailsWrapper>> {
         val body = FetchExerciseRequest(exerciseId, workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ExerciseDetailsWrapper(exerciseApi.getExerciseDetails(body)) }
         )
@@ -74,7 +74,7 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = AddNewExerciseSetRequest(exerciseId, workoutId, currentSets)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ExerciseWrapper(exerciseApi.addNewExerciseSet(body)) }
         )
@@ -88,7 +88,7 @@ class ExerciseRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<ExerciseWrapper>> {
         val body = DeleteExerciseSetRequest(exerciseId, workoutId, setId, currentSets)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ExerciseWrapper(exerciseApi.deleteExerciseSet(body)) }
         )

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/UserRemoteDataSource.kt
@@ -1,7 +1,7 @@
 package com.koleff.kare_android.data.datasource
 
-import com.koleff.kare_android.common.network.Network
 import com.koleff.kare_android.common.di.IoDispatcher
+import com.koleff.kare_android.common.network.NetworkManager
 import com.koleff.kare_android.data.model.request.FetchUserByEmail
 import com.koleff.kare_android.data.model.request.FetchUserByUsername
 import com.koleff.kare_android.data.remote.UserApi
@@ -13,12 +13,13 @@ import javax.inject.Inject
 
 class UserRemoteDataSource @Inject constructor(
     private val userApi: UserApi,
+    private val networkManager: NetworkManager,
     @IoDispatcher private val dispatcher: CoroutineDispatcher
 ) : UserDataSource {
     override suspend fun getUserByEmail(email: String): Flow<ResultWrapper<UserWrapper>> {
         val body = FetchUserByEmail(email)
 
-        return Network.executeApiCall(
+        return networkManager.executeApiCall(
             dispatcher,
             { UserWrapper(userApi.getUserByEmail(body)) }
         )
@@ -27,7 +28,7 @@ class UserRemoteDataSource @Inject constructor(
     override suspend fun getUserByUsername(username: String): Flow<ResultWrapper<UserWrapper>> {
         val body = FetchUserByUsername(username)
 
-        return Network.executeApiCall(
+        return networkManager.executeApiCall(
             dispatcher,
             { UserWrapper(userApi.getUserByUsername(body)) }
         )

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/UserRemoteDataSource.kt
@@ -1,7 +1,7 @@
 package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.di.IoDispatcher
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
 import com.koleff.kare_android.data.model.request.FetchUserByEmail
 import com.koleff.kare_android.data.model.request.FetchUserByUsername
 import com.koleff.kare_android.data.remote.UserApi
@@ -13,13 +13,13 @@ import javax.inject.Inject
 
 class UserRemoteDataSource @Inject constructor(
     private val userApi: UserApi,
-    private val networkManager: NetworkManager,
+    private val apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper,
     @IoDispatcher private val dispatcher: CoroutineDispatcher
 ) : UserDataSource {
     override suspend fun getUserByEmail(email: String): Flow<ResultWrapper<UserWrapper>> {
         val body = FetchUserByEmail(email)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { UserWrapper(userApi.getUserByEmail(body)) }
         )
@@ -28,7 +28,7 @@ class UserRemoteDataSource @Inject constructor(
     override suspend fun getUserByUsername(username: String): Flow<ResultWrapper<UserWrapper>> {
         val body = FetchUserByUsername(username)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { UserWrapper(userApi.getUserByUsername(body)) }
         )

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/WorkoutRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/WorkoutRemoteDataSource.kt
@@ -1,91 +1,122 @@
 package com.koleff.kare_android.data.datasource
 
-import com.koleff.kare_android.common.network.Network
 import com.koleff.kare_android.common.di.IoDispatcher
+import com.koleff.kare_android.common.network.NetworkManager
 import com.koleff.kare_android.data.model.dto.ExerciseDto
 import com.koleff.kare_android.data.model.dto.WorkoutConfigurationDto
 import com.koleff.kare_android.data.model.dto.WorkoutDetailsDto
 import com.koleff.kare_android.data.model.dto.WorkoutDto
 import com.koleff.kare_android.data.model.request.ExerciseAddRequest
-import com.koleff.kare_android.data.model.request.FetchWorkoutByIdRequest
 import com.koleff.kare_android.data.model.request.ExerciseDeletionRequest
+import com.koleff.kare_android.data.model.request.FetchWorkoutByIdRequest
 import com.koleff.kare_android.data.model.request.FetchWorkoutConfigurationRequest
-import com.koleff.kare_android.data.model.request.MultipleExercisesUpdateRequest
 import com.koleff.kare_android.data.model.request.MultipleExercisesDeletionRequest
+import com.koleff.kare_android.data.model.request.MultipleExercisesUpdateRequest
 import com.koleff.kare_android.data.model.request.UpdateWorkoutDetailsRequest
 import com.koleff.kare_android.data.model.request.UpdateWorkoutRequest
-import com.koleff.kare_android.domain.wrapper.WorkoutListWrapper
-import com.koleff.kare_android.domain.wrapper.WorkoutDetailsWrapper
-import com.koleff.kare_android.domain.wrapper.WorkoutWrapper
-import com.koleff.kare_android.domain.wrapper.ResultWrapper
-import com.koleff.kare_android.domain.wrapper.ServerResponseData
 import com.koleff.kare_android.data.remote.WorkoutApi
 import com.koleff.kare_android.domain.wrapper.DuplicateExercisesWrapper
-import com.koleff.kare_android.domain.wrapper.WorkoutDetailsListWrapper
-import com.koleff.kare_android.domain.wrapper.SelectedWorkoutWrapper
+import com.koleff.kare_android.domain.wrapper.ResultWrapper
+import com.koleff.kare_android.domain.wrapper.ServerResponseData
 import com.koleff.kare_android.domain.wrapper.WorkoutConfigurationWrapper
+import com.koleff.kare_android.domain.wrapper.WorkoutDetailsListWrapper
+import com.koleff.kare_android.domain.wrapper.WorkoutDetailsWrapper
+import com.koleff.kare_android.domain.wrapper.WorkoutListWrapper
+import com.koleff.kare_android.domain.wrapper.WorkoutWrapper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 
 typealias FindDuplicateExercisesRequest = MultipleExercisesUpdateRequest
+
 class WorkoutRemoteDataSource @Inject constructor(
     private val workoutApi: WorkoutApi,
+    private val networkManager: NetworkManager,
     @IoDispatcher private val dispatcher: CoroutineDispatcher
 ) : WorkoutDataSource {
     override suspend fun favoriteWorkout(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return Network.executeApiCall(dispatcher, { ServerResponseData(workoutApi.favoriteWorkout(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(workoutApi.favoriteWorkout(body)) }
+        )
     }
 
     override suspend fun unfavoriteWorkout(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return Network.executeApiCall(dispatcher, { ServerResponseData(workoutApi.unfavoriteWorkout(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(workoutApi.unfavoriteWorkout(body)) }
+        )
     }
 
     override suspend fun getFavoriteWorkouts(): Flow<ResultWrapper<WorkoutListWrapper>> {
-        return Network.executeApiCall(dispatcher, { WorkoutListWrapper(workoutApi.getFavoriteWorkouts()) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutListWrapper(workoutApi.getFavoriteWorkouts()) }
+        )
     }
 
     override suspend fun getWorkout(workoutId: Int): Flow<ResultWrapper<WorkoutWrapper>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return Network.executeApiCall(dispatcher, { WorkoutWrapper(workoutApi.getWorkout(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutWrapper(workoutApi.getWorkout(body)) }
+        )
     }
 
     override suspend fun getAllWorkouts(): Flow<ResultWrapper<WorkoutListWrapper>> {
-        return Network.executeApiCall(dispatcher, { WorkoutListWrapper(workoutApi.getAllWorkouts()) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutListWrapper(workoutApi.getAllWorkouts()) }
+        )
     }
 
     override suspend fun getAllWorkoutDetails(): Flow<ResultWrapper<WorkoutDetailsListWrapper>> {
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsListWrapper(workoutApi.getAllWorkoutDetails()) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsListWrapper(workoutApi.getAllWorkoutDetails()) }
+        )
     }
 
     override suspend fun getWorkoutDetails(workoutId: Int): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.getWorkoutDetails(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.getWorkoutDetails(body)) }
+        )
     }
 
     override suspend fun deleteWorkout(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return Network.executeApiCall(dispatcher, { ServerResponseData(workoutApi.deleteWorkout(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(workoutApi.deleteWorkout(body)) }
+        )
     }
 
     override suspend fun updateWorkoutDetails(workoutDetails: WorkoutDetailsDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = UpdateWorkoutDetailsRequest(workoutDetails)
 
-        return Network.executeApiCall(dispatcher, { ServerResponseData(workoutApi.updateWorkoutDetails(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(workoutApi.updateWorkoutDetails(body)) }
+        )
     }
 
     override suspend fun updateWorkout(workout: WorkoutDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = UpdateWorkoutRequest(workout)
 
-        return Network.executeApiCall(dispatcher, { ServerResponseData(workoutApi.updateWorkout(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(workoutApi.updateWorkout(body)) }
+        )
     }
 
     override suspend fun deleteExercise(
@@ -94,7 +125,10 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = ExerciseDeletionRequest(workoutId, exerciseId)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.deleteExercise(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.deleteExercise(body)) }
+        )
     }
 
     override suspend fun deleteMultipleExercises(
@@ -103,7 +137,10 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = MultipleExercisesDeletionRequest(workoutId, exerciseIds)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.deleteMultipleExercises(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.deleteMultipleExercises(body)) }
+        )
     }
 
     override suspend fun addExercise(
@@ -112,7 +149,10 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = ExerciseAddRequest(workoutId, exercise)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.addExercise(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.addExercise(body)) }
+        )
     }
 
     override suspend fun addMultipleExercises(
@@ -121,7 +161,10 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = MultipleExercisesUpdateRequest(workoutId, exerciseList)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.addMultipleExercises(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.addMultipleExercises(body)) }
+        )
     }
 
     override suspend fun submitExercise(
@@ -130,7 +173,10 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = ExerciseAddRequest(workoutId, exercise)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.submitExercise(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.submitExercise(body)) }
+        )
     }
 
     override suspend fun submitMultipleExercises(
@@ -139,7 +185,10 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = MultipleExercisesUpdateRequest(workoutId, exerciseList)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.submitMultipleExercises(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.submitMultipleExercises(body)) }
+        )
     }
 
     override suspend fun findDuplicateExercises(
@@ -148,46 +197,70 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<DuplicateExercisesWrapper>> {
         val body = FindDuplicateExercisesRequest(workoutId, exerciseList)
 
-        return Network.executeApiCall(dispatcher, { DuplicateExercisesWrapper(workoutApi.findDuplicateExercises(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { DuplicateExercisesWrapper(workoutApi.findDuplicateExercises(body)) }
+        )
     }
 
     override suspend fun createNewWorkout(): Flow<ResultWrapper<WorkoutWrapper>> {
-        return Network.executeApiCall(dispatcher, { WorkoutWrapper(workoutApi.createNewWorkout()) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutWrapper(workoutApi.createNewWorkout()) }
+        )
     }
 
     override suspend fun createCustomWorkout(workoutDto: WorkoutDto): Flow<ResultWrapper<WorkoutWrapper>> {
         val body = UpdateWorkoutRequest(workoutDto)
 
-        return Network.executeApiCall(dispatcher, { WorkoutWrapper(workoutApi.createCustomWorkout(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutWrapper(workoutApi.createCustomWorkout(body)) }
+        )
     }
 
     override suspend fun createCustomWorkoutDetails(workoutDetailsDto: WorkoutDetailsDto): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = UpdateWorkoutDetailsRequest(workoutDetailsDto)
 
-        return Network.executeApiCall(dispatcher, { WorkoutDetailsWrapper(workoutApi.createCustomWorkoutDetails(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutDetailsWrapper(workoutApi.createCustomWorkoutDetails(body)) }
+        )
     }
 
     override suspend fun getWorkoutConfiguration(workoutId: Int): Flow<ResultWrapper<WorkoutConfigurationWrapper>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return Network.executeApiCall(dispatcher, { WorkoutConfigurationWrapper(workoutApi.getWorkoutConfiguration(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutConfigurationWrapper(workoutApi.getWorkoutConfiguration(body)) }
+        )
     }
 
     override suspend fun updateWorkoutConfiguration(workoutConfiguration: WorkoutConfigurationDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutConfigurationRequest(workoutConfiguration)
 
-        return Network.executeApiCall(dispatcher, { ServerResponseData(workoutApi.updateWorkoutConfiguration(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(workoutApi.updateWorkoutConfiguration(body)) }
+        )
     }
 
     override suspend fun saveWorkoutConfiguration(workoutConfiguration: WorkoutConfigurationDto): Flow<ResultWrapper<WorkoutConfigurationWrapper>> {
         val body = FetchWorkoutConfigurationRequest(workoutConfiguration)
 
-        return Network.executeApiCall(dispatcher, { WorkoutConfigurationWrapper(workoutApi.saveWorkoutConfiguration(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { WorkoutConfigurationWrapper(workoutApi.saveWorkoutConfiguration(body)) }
+        )
     }
 
     override suspend fun deleteWorkoutConfiguration(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return Network.executeApiCall(dispatcher, { ServerResponseData(workoutApi.deleteWorkoutConfiguration(body)) })
+        return networkManager.executeApiCall(
+            dispatcher,
+            { ServerResponseData(workoutApi.deleteWorkoutConfiguration(body)) }
+        )
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/data/datasource/WorkoutRemoteDataSource.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/datasource/WorkoutRemoteDataSource.kt
@@ -1,7 +1,7 @@
 package com.koleff.kare_android.data.datasource
 
 import com.koleff.kare_android.common.di.IoDispatcher
-import com.koleff.kare_android.common.network.NetworkManager
+import com.koleff.kare_android.common.network.ApiAuthorizationCallWrapper
 import com.koleff.kare_android.data.model.dto.ExerciseDto
 import com.koleff.kare_android.data.model.dto.WorkoutConfigurationDto
 import com.koleff.kare_android.data.model.dto.WorkoutDetailsDto
@@ -32,13 +32,13 @@ typealias FindDuplicateExercisesRequest = MultipleExercisesUpdateRequest
 
 class WorkoutRemoteDataSource @Inject constructor(
     private val workoutApi: WorkoutApi,
-    private val networkManager: NetworkManager,
+    private val apiAuthorizationCallWrapper: ApiAuthorizationCallWrapper,
     @IoDispatcher private val dispatcher: CoroutineDispatcher
 ) : WorkoutDataSource {
     override suspend fun favoriteWorkout(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(workoutApi.favoriteWorkout(body)) }
         )
@@ -47,14 +47,14 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun unfavoriteWorkout(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(workoutApi.unfavoriteWorkout(body)) }
         )
     }
 
     override suspend fun getFavoriteWorkouts(): Flow<ResultWrapper<WorkoutListWrapper>> {
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutListWrapper(workoutApi.getFavoriteWorkouts()) }
         )
@@ -63,21 +63,21 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun getWorkout(workoutId: Int): Flow<ResultWrapper<WorkoutWrapper>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutWrapper(workoutApi.getWorkout(body)) }
         )
     }
 
     override suspend fun getAllWorkouts(): Flow<ResultWrapper<WorkoutListWrapper>> {
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutListWrapper(workoutApi.getAllWorkouts()) }
         )
     }
 
     override suspend fun getAllWorkoutDetails(): Flow<ResultWrapper<WorkoutDetailsListWrapper>> {
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsListWrapper(workoutApi.getAllWorkoutDetails()) }
         )
@@ -86,7 +86,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun getWorkoutDetails(workoutId: Int): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.getWorkoutDetails(body)) }
         )
@@ -95,7 +95,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun deleteWorkout(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(workoutApi.deleteWorkout(body)) }
         )
@@ -104,7 +104,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun updateWorkoutDetails(workoutDetails: WorkoutDetailsDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = UpdateWorkoutDetailsRequest(workoutDetails)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(workoutApi.updateWorkoutDetails(body)) }
         )
@@ -113,7 +113,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun updateWorkout(workout: WorkoutDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = UpdateWorkoutRequest(workout)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(workoutApi.updateWorkout(body)) }
         )
@@ -125,7 +125,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = ExerciseDeletionRequest(workoutId, exerciseId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.deleteExercise(body)) }
         )
@@ -137,7 +137,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = MultipleExercisesDeletionRequest(workoutId, exerciseIds)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.deleteMultipleExercises(body)) }
         )
@@ -149,7 +149,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = ExerciseAddRequest(workoutId, exercise)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.addExercise(body)) }
         )
@@ -161,7 +161,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = MultipleExercisesUpdateRequest(workoutId, exerciseList)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.addMultipleExercises(body)) }
         )
@@ -173,7 +173,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = ExerciseAddRequest(workoutId, exercise)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.submitExercise(body)) }
         )
@@ -185,7 +185,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = MultipleExercisesUpdateRequest(workoutId, exerciseList)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.submitMultipleExercises(body)) }
         )
@@ -197,14 +197,14 @@ class WorkoutRemoteDataSource @Inject constructor(
     ): Flow<ResultWrapper<DuplicateExercisesWrapper>> {
         val body = FindDuplicateExercisesRequest(workoutId, exerciseList)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { DuplicateExercisesWrapper(workoutApi.findDuplicateExercises(body)) }
         )
     }
 
     override suspend fun createNewWorkout(): Flow<ResultWrapper<WorkoutWrapper>> {
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutWrapper(workoutApi.createNewWorkout()) }
         )
@@ -213,7 +213,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun createCustomWorkout(workoutDto: WorkoutDto): Flow<ResultWrapper<WorkoutWrapper>> {
         val body = UpdateWorkoutRequest(workoutDto)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutWrapper(workoutApi.createCustomWorkout(body)) }
         )
@@ -222,7 +222,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun createCustomWorkoutDetails(workoutDetailsDto: WorkoutDetailsDto): Flow<ResultWrapper<WorkoutDetailsWrapper>> {
         val body = UpdateWorkoutDetailsRequest(workoutDetailsDto)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutDetailsWrapper(workoutApi.createCustomWorkoutDetails(body)) }
         )
@@ -231,7 +231,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun getWorkoutConfiguration(workoutId: Int): Flow<ResultWrapper<WorkoutConfigurationWrapper>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutConfigurationWrapper(workoutApi.getWorkoutConfiguration(body)) }
         )
@@ -240,7 +240,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun updateWorkoutConfiguration(workoutConfiguration: WorkoutConfigurationDto): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutConfigurationRequest(workoutConfiguration)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(workoutApi.updateWorkoutConfiguration(body)) }
         )
@@ -249,7 +249,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun saveWorkoutConfiguration(workoutConfiguration: WorkoutConfigurationDto): Flow<ResultWrapper<WorkoutConfigurationWrapper>> {
         val body = FetchWorkoutConfigurationRequest(workoutConfiguration)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { WorkoutConfigurationWrapper(workoutApi.saveWorkoutConfiguration(body)) }
         )
@@ -258,7 +258,7 @@ class WorkoutRemoteDataSource @Inject constructor(
     override suspend fun deleteWorkoutConfiguration(workoutId: Int): Flow<ResultWrapper<ServerResponseData>> {
         val body = FetchWorkoutByIdRequest(workoutId)
 
-        return networkManager.executeApiCall(
+        return apiAuthorizationCallWrapper.executeApiCall(
             dispatcher,
             { ServerResponseData(workoutApi.deleteWorkoutConfiguration(body)) }
         )

--- a/app/src/main/java/com/koleff/kare_android/data/model/request/MultipleExercisesUpdateRequest.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/model/request/MultipleExercisesUpdateRequest.kt
@@ -7,5 +7,5 @@ data class MultipleExercisesUpdateRequest(
     @field:Json(name = "workout_id")
     val workoutId: Int,
     @field:Json(name = "exercises")
-    val exerciseList: List<ExerciseDto,>
+    val exerciseList: List<ExerciseDto>
 )

--- a/app/src/main/java/com/koleff/kare_android/data/model/request/RegenerateTokenRequest.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/model/request/RegenerateTokenRequest.kt
@@ -1,0 +1,9 @@
+package com.koleff.kare_android.data.model.request
+
+import com.koleff.kare_android.data.model.dto.Tokens
+import com.squareup.moshi.Json
+
+data class RegenerateTokenRequest(
+    @field:Json(name = "tokens")
+    val tokens: Tokens
+)

--- a/app/src/main/java/com/koleff/kare_android/data/model/response/TokenResponse.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/model/response/TokenResponse.kt
@@ -1,0 +1,10 @@
+package com.koleff.kare_android.data.model.response
+
+import com.koleff.kare_android.data.model.dto.Tokens
+import com.koleff.kare_android.data.model.response.base_response.BaseResponse
+import com.squareup.moshi.Json
+
+data class TokenResponse(
+    @Json(name = "tokens")
+    val tokens: Tokens
+) : BaseResponse()

--- a/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/KareError.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/KareError.kt
@@ -22,7 +22,10 @@ enum class KareError(
     WORKOUT_NOT_FOUND("error_workout_not_found", R.string.text_workout_not_found, ErrorType.INTERNAL),
     WORKOUT_DETAILS_NOT_FOUND("error_workout_details_not_found", R.string.text_workout_details_not_found, ErrorType.INTERNAL),
     DO_WORKOUT_PERFORMANCE_METRICS_NOT_FOUND("error_do_workout_performance_metrics_not_found", R.string.text_do_workout_performance_metrics_not_found, ErrorType.INTERNAL),
-    WORKOUT_CONFIGURATION_NOT_FOUND("error_workout_configuration_not_found", R.string.text_workout_configuration_not_found, ErrorType.INTERNAL);
+    WORKOUT_CONFIGURATION_NOT_FOUND("error_workout_configuration_not_found", R.string.text_workout_configuration_not_found, ErrorType.INTERNAL),
+    TOKEN_EXPIRED("error_token_expired", R.string.text_token_expired, ErrorType.INTERNAL),
+    INVALID_TOKEN("error_invalid_token", R.string.text_invalid_token, ErrorType.INTERNAL);
+
 
 
     companion object {

--- a/app/src/main/java/com/koleff/kare_android/data/remote/AuthenticationApi.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/remote/AuthenticationApi.kt
@@ -1,8 +1,10 @@
 package com.koleff.kare_android.data.remote
 
 import com.koleff.kare_android.data.datasource.SignInRequest
+import com.koleff.kare_android.data.model.request.RegenerateTokenRequest
 import com.koleff.kare_android.data.model.request.RegistrationRequest
 import com.koleff.kare_android.data.model.response.LoginResponse
+import com.koleff.kare_android.data.model.response.TokenResponse
 import com.koleff.kare_android.data.model.response.base_response.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -24,6 +26,12 @@ interface AuthenticationApi {
     suspend fun logout(
         @Body body: RegistrationRequest
     ): BaseResponse
+
+    @GET("api/v1/auth/regeneratetoken")
+    suspend fun regenerateToken(
+        @Body body: RegenerateTokenRequest
+    ): TokenResponse
+
 
     @POST("api/v1/auth/changepassword")
     suspend fun changePassword() //TODO: implement...

--- a/app/src/main/java/com/koleff/kare_android/data/repository/AuthenticationRepositoryImpl.kt
+++ b/app/src/main/java/com/koleff/kare_android/data/repository/AuthenticationRepositoryImpl.kt
@@ -2,11 +2,13 @@ package com.koleff.kare_android.data.repository
 
 import com.koleff.kare_android.common.auth.Credentials
 import com.koleff.kare_android.data.datasource.AuthenticationDataSource
+import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
 import com.koleff.kare_android.domain.repository.AuthenticationRepository
 import com.koleff.kare_android.domain.wrapper.LoginWrapper
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.domain.wrapper.ServerResponseData
+import com.koleff.kare_android.domain.wrapper.TokenWrapper
 import kotlinx.coroutines.flow.Flow
 
 class AuthenticationRepositoryImpl(private val authenticationDataSource: AuthenticationDataSource) :
@@ -23,5 +25,9 @@ class AuthenticationRepositoryImpl(private val authenticationDataSource: Authent
 
     override suspend fun logout(user: UserDto): Flow<ResultWrapper<ServerResponseData>> {
         return authenticationDataSource.logout(user)
+    }
+
+    override suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>> {
+        return authenticationDataSource.regenerateToken(tokens)
     }
 }

--- a/app/src/main/java/com/koleff/kare_android/domain/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/com/koleff/kare_android/domain/repository/AuthenticationRepository.kt
@@ -16,5 +16,6 @@ interface AuthenticationRepository {
     suspend fun register(user: UserDto): Flow<ResultWrapper<ServerResponseData>>
 
     suspend fun logout(user: UserDto): Flow<ResultWrapper<ServerResponseData>>
+
     suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>>
 }

--- a/app/src/main/java/com/koleff/kare_android/domain/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/com/koleff/kare_android/domain/repository/AuthenticationRepository.kt
@@ -1,11 +1,12 @@
 package com.koleff.kare_android.domain.repository
 
 import com.koleff.kare_android.common.auth.Credentials
+import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.dto.UserDto
-import com.koleff.kare_android.domain.wrapper.DashboardWrapper
 import com.koleff.kare_android.domain.wrapper.LoginWrapper
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.domain.wrapper.ServerResponseData
+import com.koleff.kare_android.domain.wrapper.TokenWrapper
 import kotlinx.coroutines.flow.Flow
 
 interface AuthenticationRepository {
@@ -15,4 +16,5 @@ interface AuthenticationRepository {
     suspend fun register(user: UserDto): Flow<ResultWrapper<ServerResponseData>>
 
     suspend fun logout(user: UserDto): Flow<ResultWrapper<ServerResponseData>>
+    suspend fun regenerateToken(tokens: Tokens): Flow<ResultWrapper<TokenWrapper>>
 }

--- a/app/src/main/java/com/koleff/kare_android/domain/usecases/AuthenticationUseCases.kt
+++ b/app/src/main/java/com/koleff/kare_android/domain/usecases/AuthenticationUseCases.kt
@@ -3,5 +3,6 @@ package com.koleff.kare_android.domain.usecases
 data class AuthenticationUseCases(
     val loginUseCase: LoginUseCase,
     val registerUseCase: RegisterUseCase,
-    val logoutUseCase: LogoutUseCase
+    val logoutUseCase: LogoutUseCase,
+    val regenerateTokenUseCase: RegenerateTokenUseCase
 )

--- a/app/src/main/java/com/koleff/kare_android/domain/usecases/RegenerateTokenUseCase.kt
+++ b/app/src/main/java/com/koleff/kare_android/domain/usecases/RegenerateTokenUseCase.kt
@@ -5,19 +5,19 @@ import com.koleff.kare_android.data.model.dto.Tokens
 import com.koleff.kare_android.data.model.response.base_response.KareError
 import com.koleff.kare_android.domain.repository.AuthenticationRepository
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
-import com.koleff.kare_android.ui.state.BaseState
+import com.koleff.kare_android.ui.state.TokenState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class RegenerateTokenUseCase(
     private val authenticationRepository: AuthenticationRepository
 ) {
-    suspend operator fun invoke(tokens: Tokens): Flow<BaseState> = flow {
+    suspend operator fun invoke(tokens: Tokens): Flow<TokenState> = flow {
         authenticationRepository.regenerateToken(tokens).collect { apiResult ->
             when (apiResult) {
                 is ResultWrapper.ApiError -> {
                     emit(
-                        BaseState(
+                        TokenState(
                             isError = true,
                             error = apiResult.error ?: KareError.GENERIC
                         )
@@ -26,15 +26,16 @@ class RegenerateTokenUseCase(
 
                 is ResultWrapper.Loading -> {
                     emit(
-                        BaseState(isLoading = true)
+                        TokenState(isLoading = true)
                     )
                 }
 
                 is ResultWrapper.Success -> {
                     Log.d("RegenerateTokenUseCase", "Token regenerated successfully! New token: ${apiResult.data.tokens}")
                     emit(
-                        BaseState(
+                        TokenState(
                             isSuccessful = true,
+                            tokens = apiResult.data.tokens
                         )
                     )
                 }

--- a/app/src/main/java/com/koleff/kare_android/domain/usecases/RegenerateTokenUseCase.kt
+++ b/app/src/main/java/com/koleff/kare_android/domain/usecases/RegenerateTokenUseCase.kt
@@ -1,0 +1,44 @@
+package com.koleff.kare_android.domain.usecases
+
+import android.util.Log
+import com.koleff.kare_android.data.model.dto.Tokens
+import com.koleff.kare_android.data.model.response.base_response.KareError
+import com.koleff.kare_android.domain.repository.AuthenticationRepository
+import com.koleff.kare_android.domain.wrapper.ResultWrapper
+import com.koleff.kare_android.ui.state.BaseState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class RegenerateTokenUseCase(
+    private val authenticationRepository: AuthenticationRepository
+) {
+    suspend operator fun invoke(tokens: Tokens): Flow<BaseState> = flow {
+        authenticationRepository.regenerateToken(tokens).collect { apiResult ->
+            when (apiResult) {
+                is ResultWrapper.ApiError -> {
+                    emit(
+                        BaseState(
+                            isError = true,
+                            error = apiResult.error ?: KareError.GENERIC
+                        )
+                    )
+                }
+
+                is ResultWrapper.Loading -> {
+                    emit(
+                        BaseState(isLoading = true)
+                    )
+                }
+
+                is ResultWrapper.Success -> {
+                    Log.d("RegenerateTokenUseCase", "Token regenerated successfully! New token: ${apiResult.data.tokens}")
+                    emit(
+                        BaseState(
+                            isSuccessful = true,
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/koleff/kare_android/domain/wrapper/TokenWrapper.kt
+++ b/app/src/main/java/com/koleff/kare_android/domain/wrapper/TokenWrapper.kt
@@ -1,0 +1,8 @@
+package com.koleff.kare_android.domain.wrapper
+
+import com.koleff.kare_android.data.model.response.TokenResponse
+
+class TokenWrapper(tokenResponse: TokenResponse) :
+    ServerResponseData(tokenResponse) {
+    val tokens = tokenResponse.tokens
+}

--- a/app/src/main/java/com/koleff/kare_android/ui/state/TokenState.kt
+++ b/app/src/main/java/com/koleff/kare_android/ui/state/TokenState.kt
@@ -1,0 +1,12 @@
+package com.koleff.kare_android.ui.state
+
+import com.koleff.kare_android.data.model.dto.Tokens
+import com.koleff.kare_android.data.model.response.base_response.KareError
+
+data class TokenState (
+    val tokens: Tokens = Tokens(),
+    override val isSuccessful: Boolean = false,
+    override val isLoading: Boolean = false,
+    override val isError: Boolean = false,
+    override val error: KareError = KareError.GENERIC
+): BaseState(isSuccessful, isLoading, isError, error)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
     <string name="text_invalid_workout">Invalid workout.</string>
     <string name="text_workout_configuration_not_found">Workout configuration not found.</string>
     <string name="text_workout_details_not_found">Workout details not found.</string>
+    <string name="text_token_expired">Token expired.</string>
+    <string name="text_invalid_token">Invalid token.</string>
 </resources>

--- a/app/src/test/java/com/koleff/kare_android/authentication/AuthenticationTest.kt
+++ b/app/src/test/java/com/koleff/kare_android/authentication/AuthenticationTest.kt
@@ -20,6 +20,7 @@ import com.koleff.kare_android.domain.repository.UserRepository
 import com.koleff.kare_android.domain.usecases.AuthenticationUseCases
 import com.koleff.kare_android.domain.usecases.LoginUseCase
 import com.koleff.kare_android.domain.usecases.LogoutUseCase
+import com.koleff.kare_android.domain.usecases.RegenerateTokenUseCase
 import com.koleff.kare_android.domain.usecases.RegisterUseCase
 import com.koleff.kare_android.domain.wrapper.ResultWrapper
 import com.koleff.kare_android.utils.TestLogger
@@ -224,7 +225,8 @@ class AuthenticationTest {
                     authenticationRepository,
                     credentialsAuthenticator
                 ),
-                logoutUseCase = LogoutUseCase(authenticationRepository)
+                logoutUseCase = LogoutUseCase(authenticationRepository),
+                regenerateTokenUseCase = RegenerateTokenUseCase(authenticationRepository)
             )
 
             logger = TestLogger(isLogging)
@@ -536,4 +538,7 @@ class AuthenticationTest {
         logger.i(TAG, "Data: $registerState")
         assertTrue { registerState[1].isError && registerState[1].error == KareError.INVALID_CREDENTIALS }
     }
+
+    //TODO: [Test] logout...
+    //TODO: [Test] regenerate token on expire...
 }

--- a/shared-test/src/main/java/com/koleff/kare_android/authentication/data/CredentialsDataStoreFake.kt
+++ b/shared-test/src/main/java/com/koleff/kare_android/authentication/data/CredentialsDataStoreFake.kt
@@ -1,14 +1,24 @@
 package com.koleff.kare_android.authentication.data
 
 import com.koleff.kare_android.common.auth.Credentials
-import com.koleff.kare_android.common.auth.CredentialsDataStore
+import com.koleff.kare_android.common.preferences.CredentialsDataStore
 
-class CredentialsDataStoreFake: CredentialsDataStore {
+class CredentialsDataStoreFake : CredentialsDataStore {
+    private var credentials: Credentials? = null
+    var isCleared = false
+        private set
+
     override fun getCredentials(): Credentials? {
-        return null
+        return credentials
     }
 
     override fun saveCredentials(credentials: Credentials) {
+        this.credentials = credentials
+        isCleared = false
+    }
 
+    override fun deleteCredentials() {
+        credentials = null
+        isCleared = true
     }
 }

--- a/shared-test/src/main/java/com/koleff/kare_android/authentication/data/NavigationControllerFake.kt
+++ b/shared-test/src/main/java/com/koleff/kare_android/authentication/data/NavigationControllerFake.kt
@@ -1,0 +1,44 @@
+package com.koleff.kare_android.authentication.data
+
+import com.koleff.kare_android.common.navigation.Destination
+import com.koleff.kare_android.common.navigation.NavigationController
+
+class NavigationControllerFake: NavigationController {
+    var lastDestination: Destination? = null
+        private set
+
+    var lastPopUpToRoute: String? = null
+        private set
+
+    var lastDestinationRoute: String? = null
+        private set
+
+    var isBackstackCleared = false
+        private set
+
+    var isNavigateBackCalled = false
+        private set
+
+    override suspend fun navigateTo(destination: Destination) {
+        lastDestination = destination
+    }
+
+    override suspend fun clearBackstackAndNavigateTo(destination: Destination) {
+        isBackstackCleared = true
+        lastDestination = destination
+    }
+
+    override suspend fun popUpToAndNavigateTo(
+        popUpToRoute: String,
+        destinationRoute: String,
+        inclusive: Boolean,
+        saveState: Boolean
+    ) {
+        lastPopUpToRoute = popUpToRoute
+        lastDestinationRoute = destinationRoute
+    }
+
+    override suspend fun navigateBack() {
+        isNavigateBackCalled = true
+    }
+}

--- a/shared-test/src/main/java/com/koleff/kare_android/authentication/data/RegenerateTokenNotifierFake.kt
+++ b/shared-test/src/main/java/com/koleff/kare_android/authentication/data/RegenerateTokenNotifierFake.kt
@@ -1,0 +1,16 @@
+package com.koleff.kare_android.authentication.data
+
+import com.koleff.kare_android.common.broadcast.RegenerateTokenNotifier
+import com.koleff.kare_android.ui.state.TokenState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class RegenerateTokenNotifierFake : RegenerateTokenNotifier {
+    private var _regenerateTokenState = MutableStateFlow(TokenState())
+    override val regenerateTokenState: Flow<TokenState> = _regenerateTokenState.asSharedFlow()
+
+    fun emit(state: TokenState) {
+        _regenerateTokenState.value = state
+    }
+}

--- a/shared-test/src/main/java/com/koleff/kare_android/authentication/data/TokenDataStoreFake.kt
+++ b/shared-test/src/main/java/com/koleff/kare_android/authentication/data/TokenDataStoreFake.kt
@@ -1,0 +1,24 @@
+package com.koleff.kare_android.authentication.data
+
+import com.koleff.kare_android.common.preferences.TokenDataStore
+import com.koleff.kare_android.data.model.dto.Tokens
+
+class TokenDataStoreFake: TokenDataStore {
+    private var tokens: Tokens? = null
+    var isCleared = false
+        private set
+
+    override fun getTokens(): Tokens? {
+        return tokens
+    }
+
+    override fun updateTokens(tokens: Tokens) {
+        this.tokens = tokens
+        isCleared = false
+    }
+
+    override fun deleteTokens() {
+        tokens = null
+        isCleared = true
+    }
+}


### PR DESCRIPTION
In this branch l have:
- Refactored Network to ApiAuthenticationCallWrapper (for API requests that require authorization) and ApiCallWrapper (for API requests that don't require authorization)
- Added RegenerateTokenInterceptor
- Separated DI modules
- Fixed NavigationControllerImpl injection/binding
- Added regenerateToken and logout broadcast receivers
- Added tests for regenerateToken and logout broadcast receivers
- Updated testing components
- Added TokenDataStore